### PR TITLE
Error if try to purchase when cannot make payments

### DIFF
--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -111,6 +111,12 @@ public class SwiftyStoreKit {
 
     // MARK: private methods
     private func purchase(product product: SKProduct, completion: (result: PurchaseResultType) -> ()) {
+        guard SwiftyStoreKit.canMakePayments else {
+            let error = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: "Cannot make payments" ])
+            completion(result: PurchaseResultType.Error(error: error))
+            return
+        }
+
         guard let productIdentifier = product._productIdentifier else {
             let error = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: "No product identifier" ])
             completion(result: PurchaseResultType.Error(error: error))


### PR DESCRIPTION
Just an idea to refine

If cannot make payments, throw an error instead of trying

This error could be a `case` of an already existed `ErrorType` or new one,  instead of `NSError` created in the PR
Could be named `PaymentNotAllowed`

Maybe
- optional feature with a `boolean` variable
- also apply this to restore purchases

what do you think?