### PR TITLE
Fix Swift 2.2 warnings in SwiftyStoreDemo

### DIFF
--- a/SwiftyStoreDemo/NetworkActivityIndicatorManager.swift
+++ b/SwiftyStoreDemo/NetworkActivityIndicatorManager.swift
@@ -33,12 +33,12 @@ class NetworkActivityIndicatorManager: NSObject {
         if loadingCount == 0 {
             UIApplication.sharedApplication().networkActivityIndicatorVisible = true
         }
-        loadingCount++
+        loadingCount += 1
     }
     
     class func networkOperationFinished() {
         if loadingCount > 0 {
-            loadingCount--
+            loadingCount -= 1
         }
         if loadingCount == 0 {
             UIApplication.sharedApplication().networkActivityIndicatorVisible = false


### PR DESCRIPTION
This commit fixes:
- '++' is deprecated: it will be removed in Swift 3
- '--' is deprecated: it will be removed in Swift 3