### PR TITLE
Remove unnecessary break statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ SwiftyStoreKit.retrieveProductInfo("com.musevisions.SwiftyStoreKit.Purchase1") {
     case .Success(let product):
         let priceString = NSNumberFormatter.localizedStringFromNumber(product.price, numberStyle: .CurrencyStyle)
         print("Product: \(product.localizedDescription), price: \(priceString)")
-        break
     case .Error(let error):
         print("Error: \(error)")
-        break
     }
 }
 ```
@@ -39,10 +37,8 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1") { res
     switch result {
     case .Success(let productId):
         print("Purchase Success: \(productId)")
-        break
     case .Error(let error):
         print("Purchase Failed: \(error)")
-        break
     }
 }
 ```
@@ -54,13 +50,10 @@ SwiftyStoreKit.restorePurchases() { result in
     switch result {
     case .Success(let productId):
         print("Restore Success: \(productId)")
-        break
     case .NothingToRestore:
         print("Nothing to Restore")
-        break
     case .Error(let error):
         print("Restore Failed: \(error)")
-        break
     }
 }
 ```
@@ -81,10 +74,8 @@ func refreshReceipt() {
         switch result {
         case .Success:
             print("Receipt refresh success")
-            break
         case .Error(let error):
             print("Receipt refresh failed: \(error)")
-            break
         }
     }
 }

--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -104,7 +104,6 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
                     self.callback(result: .Purchased(productId: transaction.payment.productIdentifier))
                 })
                 paymentQueue.finishTransaction(transaction)
-                break
             case .Failed:
                 dispatch_async(dispatch_get_main_queue(), {
                     // It appears that in some edge cases transaction.error is nil here. Since returning an associated error is
@@ -113,13 +112,11 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
                     self.callback(result: .Failed(error: transaction.error ?? altError))
                 })
                 paymentQueue.finishTransaction(transaction)
-                break
             case .Restored:
                 dispatch_async(dispatch_get_main_queue(), {
                     self.callback(result: .Restored(productId: transaction.payment.productIdentifier))
                 })
                 paymentQueue.finishTransaction(transaction)
-                break
             case .Purchasing:
                 // In progress: do nothing
                 break

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -154,10 +154,8 @@ public class SwiftyStoreKit {
                 } else {
                     completion(result: .Success)
                 }
-                break
             case .Error(let e):
                 completion(result: .Error(error: e))
-                break
             }
         }
     }


### PR DESCRIPTION
Very subtle change: Swift does not require explicit `break`. IMHO removing that kind of noise improves readability of both documentation and the code.