### PR TITLE
Restore Purchase call to return all restored purchase IDs at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1") { res
 ### Restore previous purchases
 
 ```swift
-SwiftyStoreKit.restorePurchases() { result in
-    switch result {
-    case .Success(let productId):
-        print("Restore Success: \(productId)")
-    case .NothingToRestore:
+SwiftyStoreKit.restorePurchases() { results in
+    if results.restoreFailedProducts.count > 0 {
+        print("Restore Failed: \(results.restoreFailedProducts)")
+    }
+    else if results.restoredProductIds.count > 0 {
+        print("Restore Success: \(results.restoredProductIds)")
+    }
+    else {
         print("Nothing to Restore")
-    case .Error(let error):
-        print("Restore Failed: \(error)")
     }
 }
 ```

--- a/SwiftyStoreDemo/ViewController.swift
+++ b/SwiftyStoreDemo/ViewController.swift
@@ -154,18 +154,19 @@ extension ViewController {
         }
     }
     
-    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResult) -> UIAlertController {
-        
-        switch result {
-        case .Success(let productId):
-            print("Restore Success: \(productId)")
+    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResults) -> UIAlertController {
+
+        if result.restoreFailedProducts.count > 0 {
+            print("Restore Failed: \(result.restoreFailedProducts)")
+            return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
+        }
+        else if result.restoredProductIds.count > 0 {
+            print("Restore Success: \(result.restoredProductIds)")
             return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
-        case .NothingToRestore:
+        }
+        else {
             print("Nothing to Restore")
             return alertWithTitle("Nothing to restore", message: "No previous purchases were found")
-        case .Error(let error):
-            print("Restore Failed: \(error)")
-            return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
         }
     }
 

--- a/SwiftyStoreDemo/ViewController.swift
+++ b/SwiftyStoreDemo/ViewController.swift
@@ -66,10 +66,10 @@ class ViewController: UIViewController {
     @IBAction func restorePurchases() {
         
         NetworkActivityIndicatorManager.networkOperationStarted()
-        SwiftyStoreKit.restorePurchases() { result in
+        SwiftyStoreKit.restorePurchases() { results in
             NetworkActivityIndicatorManager.networkOperationFinished()
             
-            self.showAlert(self.alertForRestorePurchases(result))
+            self.showAlert(self.alertForRestorePurchases(results))
         }
     }
 
@@ -154,14 +154,14 @@ extension ViewController {
         }
     }
     
-    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResults) -> UIAlertController {
+    func alertForRestorePurchases(results: SwiftyStoreKit.RestoreResults) -> UIAlertController {
 
-        if result.restoreFailedProducts.count > 0 {
-            print("Restore Failed: \(result.restoreFailedProducts)")
+        if results.restoreFailedProducts.count > 0 {
+            print("Restore Failed: \(results.restoreFailedProducts)")
             return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
         }
-        else if result.restoredProductIds.count > 0 {
-            print("Restore Success: \(result.restoredProductIds)")
+        else if results.restoredProductIds.count > 0 {
+            print("Restore Success: \(results.restoredProductIds)")
             return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
         }
         else {

--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -153,7 +153,6 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
             self.callback(results: [])
             return
         }
-        //print("\(restored)")
     }
     
     func paymentQueue(queue: SKPaymentQueue, updatedDownloads downloads: [SKDownload]) {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -58,10 +58,9 @@ public class SwiftyStoreKit {
         case Success(product: SKProduct)
         case Error(error: ErrorType)
     }
-    public enum RestoreResult {
-        case Success(productId: String)
-        case Error(error: ErrorType)
-        case NothingToRestore
+    public struct RestoreResults {
+        public let restoredProductIds: [String]
+        public let restoreFailedProducts: [(ErrorType, String?)]
     }
     public enum RefreshReceiptResult {
         case Success
@@ -115,13 +114,14 @@ public class SwiftyStoreKit {
         }
     }
     
-    public class func restorePurchases(completion: (result: RestoreResult) -> ()) {
+    public class func restorePurchases(completion: (results: RestoreResults) -> ()) {
 
-        sharedInstance.restoreRequest = InAppProductPurchaseRequest.restorePurchases() { result in
+        // Called multiple
+        sharedInstance.restoreRequest = InAppProductPurchaseRequest.restorePurchases() { results in
         
             sharedInstance.restoreRequest = nil
-            let returnValue = sharedInstance.processRestoreResult(result)
-            completion(result: returnValue)
+            let results = sharedInstance.processRestoreResults(results)
+            completion(results: results)
         }
     }
 
@@ -177,13 +177,15 @@ public class SwiftyStoreKit {
             return
         }
 
-        inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product) { result in
+        inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product) { results in
 
             if let productIdentifier = product._productIdentifier {
                 self.inflightPurchases[productIdentifier] = nil
             }
-            let returnValue = self.processPurchaseResult(result)
-            completion(result: returnValue)
+            if let purchasedProductTransaction = results.first {
+                let returnValue = self.processPurchaseResult(purchasedProductTransaction)
+                completion(result: returnValue)
+            }
         }
     }
 
@@ -195,23 +197,25 @@ public class SwiftyStoreKit {
             return .Error(error: .Failed(error: error))
         case .Restored(let productId):
             return .Error(error: .Failed(error: storeInternalError(code: InternalErrorCode.RestoredPurchaseWhenPurchasing.rawValue, description: "Cannot restore product \(productId) from purchase path")))
-        case .NothingToRestore:
-            return .Error(error: .Failed(error: storeInternalError(code: InternalErrorCode.NothingToRestoreWhenPurchasing.rawValue, description: "Cannot restore product from purchase path")))
         }
     }
     
-    private func processRestoreResult(result: InAppProductPurchaseRequest.TransactionResult) -> RestoreResult {
-        switch result {
-        case .Purchased(let productId):
-            return .Error(error: storeInternalError(code: InternalErrorCode.PurchasedWhenRestoringPurchase.rawValue, description: "Cannot purchase product \(productId) from restore purchases path"))
-        case .Failed(let error):
-            return .Error(error: error)
-        case .Restored(let productId):
-            return .Success(productId: productId)
-        case .NothingToRestore:
-            return .NothingToRestore
+    private func processRestoreResults(results: [InAppProductPurchaseRequest.TransactionResult]) -> RestoreResults {
+        var restoredProductIds: [String] = []
+        var restoreFailedProducts: [(ErrorType, String?)] = []
+        for result in results {
+            switch result {
+            case .Purchased(let productId):
+                restoreFailedProducts.append((storeInternalError(code: InternalErrorCode.PurchasedWhenRestoringPurchase.rawValue, description: "Cannot purchase product \(productId) from restore purchases path"), productId))
+            case .Failed(let error):
+                restoreFailedProducts.append((error, nil))
+            case .Restored(let productId):
+                restoredProductIds.append(productId)
+            }
         }
+        return RestoreResults(restoredProductIds: restoredProductIds, restoreFailedProducts: restoreFailedProducts)
     }
+    
     
     // http://appventure.me/2015/06/19/swift-try-catch-asynchronous-closures/
     private func requestProduct(productId: String, completion: (result: (() throws -> SKProduct)) -> ()) -> () {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -68,8 +68,7 @@ public class SwiftyStoreKit {
     }
     public enum InternalErrorCode: Int {
         case RestoredPurchaseWhenPurchasing = 0
-        case NothingToRestoreWhenPurchasing = 1
-        case PurchasedWhenRestoringPurchase = 2
+        case PurchasedWhenRestoringPurchase = 1
     }
 
     // MARK: Singleton

--- a/SwiftyStoreOSXDemo/ViewController.swift
+++ b/SwiftyStoreOSXDemo/ViewController.swift
@@ -61,9 +61,9 @@ class ViewController: NSViewController {
 
     @IBAction func restorePurchases(sender: AnyObject?) {
 
-        SwiftyStoreKit.restorePurchases() { result in
+        SwiftyStoreKit.restorePurchases() { results in
             
-            self.showAlert(self.alertForRestorePurchases(result))
+            self.showAlert(self.alertForRestorePurchases(results))
         }
     }
 
@@ -140,21 +140,22 @@ extension ViewController {
         }
     }
     
-    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResult) -> NSAlert {
+    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResults) -> NSAlert {
         
-        switch result {
-        case .Success(let productId):
-            print("Restore Success: \(productId)")
-            return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
-        case .NothingToRestore:
-            print("Nothing to Restore")
-            return alertWithTitle("Nothing to restore", message: "No previous purchases were found")
-        case .Error(let error):
-            print("Restore Failed: \(error)")
+        if result.restoreFailedProducts.count > 0 {
+            print("Restore Failed: \(result.restoreFailedProducts)")
             return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
         }
+        else if result.restoredProductIds.count > 0 {
+            print("Restore Success: \(result.restoredProductIds)")
+            return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
+        }
+        else {
+            print("Nothing to Restore")
+            return alertWithTitle("Nothing to restore", message: "No previous purchases were found")
+        }
     }
-
+    
     func alertForVerifyReceipt(result: SwiftyStoreKit.VerifyReceiptResult) -> NSAlert {
 
         switch result {

--- a/SwiftyStoreOSXDemo/ViewController.swift
+++ b/SwiftyStoreOSXDemo/ViewController.swift
@@ -140,14 +140,14 @@ extension ViewController {
         }
     }
     
-    func alertForRestorePurchases(result: SwiftyStoreKit.RestoreResults) -> NSAlert {
+    func alertForRestorePurchases(results: SwiftyStoreKit.RestoreResults) -> NSAlert {
         
-        if result.restoreFailedProducts.count > 0 {
-            print("Restore Failed: \(result.restoreFailedProducts)")
+        if results.restoreFailedProducts.count > 0 {
+            print("Restore Failed: \(results.restoreFailedProducts)")
             return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
         }
-        else if result.restoredProductIds.count > 0 {
-            print("Restore Success: \(result.restoredProductIds)")
+        else if results.restoredProductIds.count > 0 {
+            print("Restore Success: \(results.restoredProductIds)")
             return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
         }
         else {


### PR DESCRIPTION
Related to this:

https://github.com/bizz84/SwiftyStoreKit/issues/18

This is a tentative solution that gathers together all restored purchases. `NothingToRestore` is no longer returned when there are no purchases to restore - instead the client can check that the `restoredProductIDs` array is empty.

Some feedback is welcome for this pull request before it is merged as it breaks API compatibility with the older versions.

