### PR TITLE
Each InAppProductPurchaseRequest to handle only its own transactions

### DIFF
--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -57,6 +57,7 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
     }
     // MARK: Public methods
     class func startPayment(product: SKProduct, callback: RequestCallback) -> InAppProductPurchaseRequest {
+        //print("start payment: \(product._productIdentifier)")
         let request = InAppProductPurchaseRequest(product: product, callback: callback)
         request.startPayment(product)
         return request
@@ -90,6 +91,12 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
         var transactionResults: [TransactionResult] = []
         
         for transaction in transactions {
+            if let productIdentifier = product?._productIdentifier {
+                if transaction.payment.productIdentifier != productIdentifier {
+                    //print("productId: \(productIdentifier). Discarding queue transaction for \(transaction.payment.productIdentifier)")
+                    continue
+                }
+            }
 
             #if os(iOS)
                 let transactionState = transaction.transactionState

--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -57,7 +57,6 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
     }
     // MARK: Public methods
     class func startPayment(product: SKProduct, callback: RequestCallback) -> InAppProductPurchaseRequest {
-        //print("start payment: \(product._productIdentifier)")
         let request = InAppProductPurchaseRequest(product: product, callback: callback)
         request.startPayment(product)
         return request
@@ -71,6 +70,8 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
     // MARK: Private methods
     private func startPayment(product: SKProduct) {
         guard let _ = product._productIdentifier else {
+            let error = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: "Missing product identifier" ])
+            callback(results: [ TransactionResult.Failed(error: error) ])
             return
         }
         let payment = SKMutablePayment(product: product)
@@ -84,18 +85,22 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
             self.paymentQueue.restoreCompletedTransactions()
         }
     }
-    
+        
     // MARK: SKPaymentTransactionObserver
     func paymentQueue(queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         
         var transactionResults: [TransactionResult] = []
         
         for transaction in transactions {
+            
+            let transactionProductIdentifier = transaction.payment.productIdentifier
+            
+            var isPurchaseRequest = false
             if let productIdentifier = product?._productIdentifier {
-                if transaction.payment.productIdentifier != productIdentifier {
-                    //print("productId: \(productIdentifier). Discarding queue transaction for \(transaction.payment.productIdentifier)")
+                if transactionProductIdentifier != productIdentifier {
                     continue
                 }
+                isPurchaseRequest = true
             }
 
             #if os(iOS)
@@ -106,17 +111,22 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
 
             switch transactionState {
             case .Purchased:
-                transactionResults.append(.Purchased(productId: transaction.payment.productIdentifier))
-                paymentQueue.finishTransaction(transaction)
+                if isPurchaseRequest {
+                    transactionResults.append(.Purchased(productId: transactionProductIdentifier))
+                    paymentQueue.finishTransaction(transaction)
+                }
             case .Failed:
+                // TODO: How to discriminate between purchase and restore?
                 // It appears that in some edge cases transaction.error is nil here. Since returning an associated error is
                 // mandatory, return a default one if needed
                 let altError = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: "Unknown error" ])
                 transactionResults.append(.Failed(error: transaction.error ?? altError))
                 paymentQueue.finishTransaction(transaction)
             case .Restored:
-                transactionResults.append(.Restored(productId: transaction.payment.productIdentifier))
-                paymentQueue.finishTransaction(transaction)
+                if !isPurchaseRequest {
+                    transactionResults.append(.Restored(productId: transactionProductIdentifier))
+                    paymentQueue.finishTransaction(transaction)
+                }
             case .Purchasing:
                 // In progress: do nothing
                 break
@@ -125,10 +135,10 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
             }
             // Keep track of payments
             if let _ = purchases[transactionState] {
-                purchases[transactionState]?.append(transaction.payment.productIdentifier)
+                purchases[transactionState]?.append(transactionProductIdentifier)
             }
             else {
-                purchases[transactionState] = [ transaction.payment.productIdentifier ]
+                purchases[transactionState] = [ transactionProductIdentifier ]
             }
         }
         if transactionResults.count > 0 {
@@ -150,10 +160,6 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
     }
 
     func paymentQueueRestoreCompletedTransactionsFinished(queue: SKPaymentQueue) {
-        if let product = self.product, productIdentifier = product._productIdentifier {
-            self.callback(results: [.Restored(productId: productIdentifier)])
-            return
-        }
         // This method will be called after all purchases have been restored (includes the case of no purchases)
         guard let restored = purchases[.Restored] where restored.count > 0 else {
             

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -115,10 +115,8 @@ public class SwiftyStoreKit {
     
     public class func restorePurchases(completion: (results: RestoreResults) -> ()) {
 
-        print("> begin restore purchases")
         sharedInstance.restoreRequest = InAppProductPurchaseRequest.restorePurchases() { results in
         
-            print("< end restore purchases")
             sharedInstance.restoreRequest = nil
             let results = sharedInstance.processRestoreResults(results)
             completion(results: results)
@@ -177,10 +175,8 @@ public class SwiftyStoreKit {
             return
         }
 
-        print("> begin purchase: \(productIdentifier)")
         inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product) { results in
 
-            print("< end purchase: \(productIdentifier)")
             self.inflightPurchases[productIdentifier] = nil
             
             if let purchasedProductTransaction = results.first {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -115,9 +115,10 @@ public class SwiftyStoreKit {
     
     public class func restorePurchases(completion: (results: RestoreResults) -> ()) {
 
-        // Called multiple
+        print("> begin restore purchases")
         sharedInstance.restoreRequest = InAppProductPurchaseRequest.restorePurchases() { results in
         
+            print("< end restore purchases")
             sharedInstance.restoreRequest = nil
             let results = sharedInstance.processRestoreResults(results)
             completion(results: results)
@@ -176,11 +177,12 @@ public class SwiftyStoreKit {
             return
         }
 
+        print("> begin purchase: \(productIdentifier)")
         inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product) { results in
 
-            if let productIdentifier = product._productIdentifier {
-                self.inflightPurchases[productIdentifier] = nil
-            }
+            print("< end purchase: \(productIdentifier)")
+            self.inflightPurchases[productIdentifier] = nil
+            
             if let purchasedProductTransaction = results.first {
                 let returnValue = self.processPurchaseResult(purchasedProductTransaction)
                 completion(result: returnValue)


### PR DESCRIPTION
InAppProductPurchaseRequest should only acknowledge transactions matching the specified product identifier. If multiple purchases are in flight at the same time, multiple InAppProductPurchaseRequests will be active and each should handle only its own transactions