### PR TITLE
Verify purchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,35 @@ func refreshReceipt() {
 }
 ```
 
+### Verify purchase of a product in a receipt
+
+```swift
+SwiftyStoreKit.verifyReceipt() { result in
+    switch result {
+    case .Success(let receipt):
+
+        let purchaseResult = SwiftyStoreKit.verifyPurchase(
+            productId: "com.musevisions.SwiftyStoreKit.Purchase1",
+            inReceipt: receipt
+        )
+        switch purchaseResult {
+        case .Purchased(let expiresDate):
+            print("Product is purchased.")
+            if expiresDate != nil { // Only for Automatically Renewable Subscription
+              print("Product is valid until \(expiresDate)")
+            }
+        case .Expired(let expiresDate): // Only for Automatically Renewable Subscription
+            print("Product is expired since \(expiresDate)")
+        case .NotPurchased:
+            print("The user has never purchased this product")
+        }
+
+    case .Error(let error):
+        print("Receipt verification failed: \(error)")
+    }
+}
+```
+
 ### Complete Transactions
 
 This can be used to finish any transactions that were pending in the payment queue after the app has been terminated. Should be called when the app starts.

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -160,6 +160,20 @@ public class SwiftyStoreKit {
         completion:(result: VerifyReceiptResult) -> ()) {
             InAppReceipt.verify(receiptVerifyURL: url, password: password, session: session, completion: completion)
     }
+  
+    /**
+     *  Verify the purchase of a product in a receipt
+     *  - Parameter productId: the product id of the purchase to verify
+     *  - Parameter inReceipt: the receipt to test in
+     *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
+     */
+    public class func verifyPurchase(
+        productId productId: String,
+        inReceipt receipt: ReceiptInfo,
+        validUntil: NSDate? = nil
+    ) -> SwiftyStoreKit.VerifyPurchaseResult {
+        return InAppReceipt.verifyPurchase(productId: productId, inReceipt: receipt, validUntil: validUntil)
+    }
 
     #if os(iOS) || os(tvOS)
     // After verifying receive and have `ReceiptError.NoReceiptData`, refresh receipt using this method


### PR DESCRIPTION
Add the `SwiftyStoreKit.verifyPurchase` function to easily verify that a purchase is present (and not expired for Automatically Renewable Subscription) from the receipt.

I use `receipt["receipt"]["in_app"]`array for making the verification but it is also possible to use `receipt["latest_receipt_info"]` array. It seems that the `in_app` array contains every purchase and the `latest_receipt_info` array only the latest.
I am not sure about which one to choose. What do you think ?