### PR TITLE
Verify purchase

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,28 @@ SwiftyStoreKit.verifyReceipt() { result in
     switch result {
     case .Success(let receipt):
 
+        // Verify the purchase of Consumable, NonConsumable, FreeSubscription or NonRenewingSubscription
         let purchaseResult = SwiftyStoreKit.verifyPurchase(
             productId: "com.musevisions.SwiftyStoreKit.Purchase1",
-            inReceipt: receipt,
-            purchaseType: .NonConsumable
+            inReceipt: receipt
         )
         switch purchaseResult {
         case .Purchased(let expiresDate):
             print("Product is purchased.")
-            if expiresDate != nil { // Only for Automatically Renewable Subscription
-              print("Product is valid until \(expiresDate)")
-            }
-        case .Expired(let expiresDate): // Only for Automatically Renewable Subscription
+        case .NotPurchased:
+            print("The user has never purchased this product")
+        }
+        
+        // Verify the purchase of AutomaticallyRenewableSubscription only
+        let purchaseResult = SwiftyStoreKit.verifyAutomaticallyRenewableSubscription(
+            productId: "com.musevisions.SwiftyStoreKit.Purchase1",
+            validUntil: NSDate(),
+            inReceipt: receipt
+        )
+        switch purchaseResult {
+        case .Purchased(let expiresDate):
+            print("Product is valid until \(expiresDate)")
+        case .Expired(let expiresDate):
             print("Product is expired since \(expiresDate)")
         case .NotPurchased:
             print("The user has never purchased this product")

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ SwiftyStoreKit.verifyReceipt() { result in
     switch result {
     case .Success(let receipt):
 
-        // Verify the purchase of Consumable, NonConsumable, FreeSubscription or NonRenewingSubscription
+        // Verify the purchase of Consumable or NonConsumable
         let purchaseResult = SwiftyStoreKit.verifyPurchase(
             productId: "com.musevisions.SwiftyStoreKit.Purchase1",
             inReceipt: receipt
@@ -104,11 +104,27 @@ SwiftyStoreKit.verifyReceipt() { result in
             print("The user has never purchased this product")
         }
         
-        // Verify the purchase of AutomaticallyRenewableSubscription only
-        let purchaseResult = SwiftyStoreKit.verifyAutomaticallyRenewableSubscription(
-            productId: "com.musevisions.SwiftyStoreKit.Purchase1",
+        // Example for an Automatically Renewable Subscription
+        let purchaseResult = SwiftyStoreKit.verifySubscription(
+            productId: "com.musevisions.SwiftyStoreKit.AutomaticallyRenewableSubscription",
+            inReceipt: receipt,
+            validUntil: NSDate()
+        )
+        switch purchaseResult {
+        case .Purchased(let expiresDate):
+            print("Product is valid until \(expiresDate)")
+        case .Expired(let expiresDate):
+            print("Product is expired since \(expiresDate)")
+        case .NotPurchased:
+            print("The user has never purchased this product")
+        }
+        
+        // Example for a Non Renewing Subscription
+        let purchaseResult = SwiftyStoreKit.verifySubscription(
+            productId: "com.musevisions.SwiftyStoreKit.1MonthNonRenewingSubscription",
+            inReceipt: receipt,
             validUntil: NSDate(),
-            inReceipt: receipt
+            validDuration: 3600 * 24 * 30, //1 month duration
         )
         switch purchaseResult {
         case .Purchased(let expiresDate):
@@ -124,6 +140,10 @@ SwiftyStoreKit.verifyReceipt() { result in
     }
 }
 ```
+
+To test the expiration of a Non Renewing Subscription, you must indicate the `validDuration` time interval in second.
+
+Note for the purchase of a consumable product, the receipt will contain it only for a couples of minutes after the purchase.
 
 ### Complete Transactions
 

--- a/SwiftyStoreDemo/ViewController.swift
+++ b/SwiftyStoreDemo/ViewController.swift
@@ -119,7 +119,7 @@ class ViewController: UIViewController {
               
                 // Specific behaviour for AutoRenewablePurchase
                 if purchase == .AutoRenewablePurchase {
-                    let purchaseResult = SwiftyStoreKit.verifyAutoRenewableSubscription(
+                    let purchaseResult = SwiftyStoreKit.verifySubscription(
                         productId: self.AppBundleId + "." + purchase.rawValue,
                         inReceipt: receipt,
                         validUntil: NSDate()
@@ -245,7 +245,7 @@ extension ViewController {
         }
     }
   
-    func alertForVerifyPurchase(result: SwiftyStoreKit.verifyAutoRenewableSubscriptionResult) -> UIAlertController {
+    func alertForVerifyPurchase(result: SwiftyStoreKit.verifySubscriptionResult) -> UIAlertController {
     
         switch result {
         case .Purchased(let expiresDate):

--- a/SwiftyStoreDemo/ViewController.swift
+++ b/SwiftyStoreDemo/ViewController.swift
@@ -121,8 +121,8 @@ class ViewController: UIViewController {
                 if purchase == .AutoRenewablePurchase {
                     let purchaseResult = SwiftyStoreKit.verifyAutomaticallyRenewableSubscription(
                         productId: self.AppBundleId + "." + purchase.rawValue,
-                        validUntil: NSDate(),
-                        inReceipt: receipt
+                        inReceipt: receipt,
+                        validUntil: NSDate()
                     )
                     self.showAlert(self.alertForVerifyPurchase(purchaseResult))
                 }

--- a/SwiftyStoreDemo/ViewController.swift
+++ b/SwiftyStoreDemo/ViewController.swift
@@ -119,7 +119,7 @@ class ViewController: UIViewController {
               
                 // Specific behaviour for AutoRenewablePurchase
                 if purchase == .AutoRenewablePurchase {
-                    let purchaseResult = SwiftyStoreKit.verifyAutomaticallyRenewableSubscription(
+                    let purchaseResult = SwiftyStoreKit.verifyAutoRenewableSubscription(
                         productId: self.AppBundleId + "." + purchase.rawValue,
                         inReceipt: receipt,
                         validUntil: NSDate()
@@ -245,7 +245,7 @@ extension ViewController {
         }
     }
   
-    func alertForVerifyPurchase(result: SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult) -> UIAlertController {
+    func alertForVerifyPurchase(result: SwiftyStoreKit.verifyAutoRenewableSubscriptionResult) -> UIAlertController {
     
         switch result {
         case .Purchased(let expiresDate):

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -274,8 +274,8 @@ internal class InAppReceipt {
      */
     class func verifyAutomaticallyRenewableSubscription(
         productId productId: String,
-       validUntil date: NSDate = NSDate(),
-        inReceipt receipt: ReceiptInfo
+        inReceipt receipt: ReceiptInfo,
+        validUntil date: NSDate = NSDate()
     ) -> SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult {
       
         // Verify that at least one receipt has the right product id

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -42,7 +42,7 @@ extension SwiftyStoreKit {
     }
   
     //  Result for AutomaticallyRenewableSubscription
-    public enum VerifyAutomaticallyRenewableSubscriptionResult {
+    public enum verifyAutoRenewableSubscriptionResult {
         case Purchased(expiresDate: NSDate)
         case Expired(expiresDate: NSDate)
         case NotPurchased
@@ -272,11 +272,11 @@ internal class InAppReceipt {
      *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
      *  - Parameter inReceipt: the receipt to test in
      */
-    class func verifyAutomaticallyRenewableSubscription(
+    class func verifyAutoRenewableSubscription(
         productId productId: String,
         inReceipt receipt: ReceiptInfo,
         validUntil date: NSDate = NSDate()
-    ) -> SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult {
+    ) -> SwiftyStoreKit.verifyAutoRenewableSubscriptionResult {
       
         // Verify that at least one receipt has the right product id
         guard let receiptsInfo = self.getReceiptInfo(forProductId: productId, inReceipt: receipt)

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -179,17 +179,19 @@ public class SwiftyStoreKit {
     }
   
     /**
-     *  Verify the purchase of a AutomaticallyRenewableSubscription product in a receipt
+     *  Verify the purchase of a subscription in a receipt
      *  - Parameter productId: the product id of the purchase to verify
-     *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
      *  - Parameter inReceipt: the receipt to test in
+     *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
+     *  - Parameter validDuration: the duration of the subscription. Only required for non-renewable subscription.
      */
-    public class func verifyAutoRenewableSubscription(
+    public class func verifySubscription(
         productId productId: String,
         inReceipt receipt: ReceiptInfo,
-        validUntil date: NSDate = NSDate()
-    ) -> SwiftyStoreKit.verifyAutoRenewableSubscriptionResult {
-        return InAppReceipt.verifyAutoRenewableSubscription(productId: productId, inReceipt: receipt, validUntil: date)
+        validUntil date: NSDate = NSDate(),
+        validDuration duration: NSTimeInterval? = nil
+    ) -> SwiftyStoreKit.verifySubscriptionResult {
+      return InAppReceipt.verifySubscription(productId: productId, inReceipt: receipt, validUntil: date, validDuration: duration)
     }
 
     #if os(iOS) || os(tvOS)

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -167,17 +167,29 @@ public class SwiftyStoreKit {
     }
   
     /**
-     *  Verify the purchase of a product in a receipt
+     *  Verify the purchase of a Consumable, NonConsumable, FreeSubscription or NonRenewingSubscription product in a receipt
      *  - Parameter productId: the product id of the purchase to verify
      *  - Parameter inReceipt: the receipt to test in
-     *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
      */
     public class func verifyPurchase(
         productId productId: String,
-        inReceipt receipt: ReceiptInfo,
-                  purchaseType: PurchaseType
+        inReceipt receipt: ReceiptInfo
     ) -> SwiftyStoreKit.VerifyPurchaseResult {
-        return InAppReceipt.verifyPurchase(productId: productId, inReceipt: receipt, purchaseType: purchaseType)
+        return InAppReceipt.verifyPurchase(productId: productId, inReceipt: receipt)
+    }
+  
+    /**
+     *  Verify the purchase of a AutomaticallyRenewableSubscription product in a receipt
+     *  - Parameter productId: the product id of the purchase to verify
+     *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
+     *  - Parameter inReceipt: the receipt to test in
+     */
+    public class func verifyAutomaticallyRenewableSubscription(
+      productId productId: String,
+      validUntil date: NSDate = NSDate(),
+      inReceipt receipt: ReceiptInfo
+    ) -> SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult {
+        return InAppReceipt.verifyAutomaticallyRenewableSubscription(productId: productId, validUntil: date, inReceipt: receipt)
     }
 
     #if os(iOS) || os(tvOS)

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -185,11 +185,11 @@ public class SwiftyStoreKit {
      *  - Parameter inReceipt: the receipt to test in
      */
     public class func verifyAutomaticallyRenewableSubscription(
-      productId productId: String,
-      validUntil date: NSDate = NSDate(),
-      inReceipt receipt: ReceiptInfo
+        productId productId: String,
+        inReceipt receipt: ReceiptInfo,
+        validUntil date: NSDate = NSDate()
     ) -> SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult {
-        return InAppReceipt.verifyAutomaticallyRenewableSubscription(productId: productId, validUntil: date, inReceipt: receipt)
+        return InAppReceipt.verifyAutomaticallyRenewableSubscription(productId: productId, inReceipt: receipt, validUntil: date)
     }
 
     #if os(iOS) || os(tvOS)

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -184,12 +184,12 @@ public class SwiftyStoreKit {
      *  - Parameter validUntil: the expires date of the subscription must be valid until this date. If nil, no verification
      *  - Parameter inReceipt: the receipt to test in
      */
-    public class func verifyAutomaticallyRenewableSubscription(
+    public class func verifyAutoRenewableSubscription(
         productId productId: String,
         inReceipt receipt: ReceiptInfo,
         validUntil date: NSDate = NSDate()
-    ) -> SwiftyStoreKit.VerifyAutomaticallyRenewableSubscriptionResult {
-        return InAppReceipt.verifyAutomaticallyRenewableSubscription(productId: productId, inReceipt: receipt, validUntil: date)
+    ) -> SwiftyStoreKit.verifyAutoRenewableSubscriptionResult {
+        return InAppReceipt.verifyAutoRenewableSubscription(productId: productId, inReceipt: receipt, validUntil: date)
     }
 
     #if os(iOS) || os(tvOS)


### PR DESCRIPTION
Added modifications from the pull request #36.

I split the API in 2:
- `verifyAutomaticallyRenewableSubscription`
These one should only be use for an Automatically Renewable Subscription purchase. It has an `untilDate` to check the expiration. The return of the function is a `VerifyAutomaticallyRenewableSubscriptionResult` enum with `Purchased(expiresDate: NSDate)`, `Expired(expiresDate: NSDate)`, `NotPurchased`. None of the `expiresDate` are optional as the Automatically Renewable Subscription always has a date of expiration.
- `verifyPurchase`
These one should be use by any of the other type of purchase. The API is simpler and the return of the function is a `VerifyPurchaseResult` with only `Purchased` and `NotPurchased`.

I choose the split the API in 2 because it will force the client to use the correct API when he wants to test an Automatically Renewable Subscription and also because the result of each function are specific and simpler (no more optional). These way, the API is straightforward.

If you use the `verifyAutomaticallyRenewableSubscription` function for an other purchase than an Automatically Renewable Subscription (eg: a non-consumable), the result will always be `NotPurchased`. As the `expires_date` field is not present, I consider the purchase as `NotPurchased`.
But if you use the `verifyPurchase` function for an Automatically Renewable Subscription, the result will  be `Purchased` or `NotPurchased` but the `expires_date` will not be tested!

@bizz84 What do you think of those modifications ?