### PR TITLE
Change InAppReceiptRefreshRequest's initializer to private

### DIFF
--- a/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
+++ b/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
@@ -45,7 +45,11 @@ import Foundation
         let refreshReceiptRequest: SKReceiptRefreshRequest
         let callback: RequestCallback
 
-        init(receiptProperties: [String : AnyObject]? = nil, callback: RequestCallback) {
+        deinit {
+            refreshReceiptRequest.delegate = nil
+        }
+
+        private init(receiptProperties: [String : AnyObject]? = nil, callback: RequestCallback) {
             self.callback = callback
             self.refreshReceiptRequest = SKReceiptRefreshRequest(receiptProperties: receiptProperties)
             super.init()


### PR DESCRIPTION
- Changed `InAppReceiptRefreshRequest`'s initializer to private. Because this initializer is not called from any other classes.
- Added `deinit` in `InAppReceiptRefreshRequest` for setting delegate to `nil`.