### PR TITLE
added functions to retrieve product info and localized price

### DIFF
--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -141,7 +141,35 @@ public class SwiftyStoreKit {
             }
         }
     }
+  
+    /**
+    *  Get product info
+    *  - Parameter productId: productId as specified in iTunes Connect
+    */
+    public class func product(for productIdentifier: String?) -> SKProduct? {
+      if let currentProductIdentifier = productIdentifier, let product = sharedInstance.store.products[currentProductIdentifier] {
+        return product
+      }
     
+      return nil
+    }
+  
+    /**
+    *  Get product localized price
+    *  - Parameter product: SKProduct
+    */
+    public class func localizedPrice(of product: SKProduct?) -> String? {
+    
+      guard let currentProduct = product else {
+        return nil
+      }
+    
+      let numberFormatter = NumberFormatter()
+      numberFormatter.locale = currentProduct.priceLocale
+      numberFormatter.numberStyle = .currency
+      return numberFormatter.string(from: currentProduct.price)
+    }
+  
     public class func restorePurchases(_ completion: @escaping (RestoreResults) -> ()) {
 
         sharedInstance.restoreRequest = InAppProductPurchaseRequest.restorePurchases() { results in


### PR DESCRIPTION
Thanks for making this framework! I'm migrating from `RMStore` to`SwiftyStoreKit` and I'm missing two important functions to make the migration fairly easy.

the `SKProduct`dictionary is already cached in the `SwiftyStoreKit` singleton, so it's a waste not to have a function to retrieve the product info from there. Also added a localizedPrice function (this can be an extension on `SKProduct`)

