### PR TITLE
Allowing to verify sandbox receipts

### DIFF
--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -160,9 +160,10 @@ public class SwiftyStoreKit {
      */
     public class func verifyReceipt(
         password: String? = nil,
+        production: Bool = true,
         session: URLSession = URLSession.shared,
         completion:@escaping (VerifyReceiptResult) -> ()) {
-        InAppReceipt.verify(receiptVerifyURL: .Production, password: password, session: session) { result in
+        InAppReceipt.verify(receiptVerifyURL: production ? .Production : .Test, password: password, session: session) { result in
          
             DispatchQueue.main.async {
                 completion(result)


### PR DESCRIPTION
Currently the library doesn't allow verifying sandbox receipts, because `SwiftyStoreKit.swift` has `.production` hardcoded at the `verifyReceipt` function.

By adding a `production: Bool` function parameter, it allows verifying sandbox receipts, which is essential on development.