### PR TITLE
Resolved repurchasing a non-consumable not calling completion, on macOS.

### DIFF
--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -121,7 +121,7 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
                 transactionResults.append(.failed(error: transaction.error ?? altError))
                 paymentQueue.finishTransaction(transaction)
             case .restored:
-                if !isPurchaseRequest {
+                if isPurchaseRequest {
                     transactionResults.append(.restored(productId: transactionProductIdentifier))
                     paymentQueue.finishTransaction(transaction)
                 }

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -222,7 +222,7 @@ public class SwiftyStoreKit {
             return
         }
 
-        inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product: product, atomically: atomically, applicationUsername: applicationUsername) { results in
+        inflightPurchases[productIdentifier] = InAppProductPurchaseRequest.startPayment(product, atomically: atomically, applicationUsername: applicationUsername) { results in
 
             self.inflightPurchases[productIdentifier] = nil
             
@@ -239,8 +239,8 @@ public class SwiftyStoreKit {
             return .success(product: product)
         case .failed(let error):
             return .error(error: .failed(error: error))
-        case .restored(let productId):
-            return .success(productId: productId)
+        case .restored(let product):
+            return .success(product: product)
 
         }
     }

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -263,7 +263,7 @@ public class SwiftyStoreKit {
         case .failed(let error):
             return .error(error: .failed(error: error))
         case .restored(let productId):
-            return .error(error: .failed(error: storeInternalError(code: InternalErrorCode.restoredPurchaseWhenPurchasing.rawValue, description: "Cannot restore product \(productId) from purchase path")))
+            return .success(productId: productId)
         }
     }
     


### PR DESCRIPTION
I also had this same issue.  https://github.com/bizz84/SwiftyStoreKit/issues/98

On OSX at least, when you attempt to make a payment for a non-consumable product that's already been purchased by that account the transaction result comes back as a restore. Because of the if condition in the restore case, the transaction transactionResults would never get updated. 

I've only tested this on OSX, so I can't comment on the behaviour on iOS, but from reading the code I can't see the point in the isPurchaseRequest boolean. I've reduced the protection so all it does now is avoid doing anything with non matching products identifiers, only when you're purchasing, not restoring.