### PR TITLE
Fixing subscription verifying in receipt

### DIFF
--- a/SwiftyStoreKit.xcodeproj/project.pbxproj
+++ b/SwiftyStoreKit.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		65F7DF991DCD536100835D30 /* SwiftyStoreKit-tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SwiftyStoreKit-tvOS.h"; sourceTree = "<group>"; };
 		C4083C561C2AB0A900295248 /* InAppReceiptRefreshRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppReceiptRefreshRequest.swift; sourceTree = "<group>"; };
 		C40C680F1C29414C00B60B7E /* OS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OS.swift; sourceTree = "<group>"; };
-		C4A7C7621C29B8D00053ED64 /* InAppReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppReceipt.swift; sourceTree = "<group>"; };
+		C4A7C7621C29B8D00053ED64 /* InAppReceipt.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = InAppReceipt.swift; sourceTree = "<group>"; tabWidth = 4; };
 		C4D74BBB1C24CEC90071AD3E /* SwiftyStoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyStoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4FD3A011C2954C10035CFF3 /* SwiftyStoreKit_macOSDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftyStoreKit_macOSDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -180,7 +180,7 @@ internal class InAppReceipt {
     ) -> VerifySubscriptionResult {
       
         // Verify that at least one receipt has the right product id
-        let receiptsInfo = getReceiptsInfo(forProductId: productId, inReceipt: receipt)
+        let receiptsInfo = getReceiptsInfoForSubscriptions(forProductId: productId, inReceipt: receipt)
         if receiptsInfo.count == 0 {
             return .notPurchased
         }
@@ -252,6 +252,30 @@ internal class InAppReceipt {
                 return product_id == productId
             }
       
+        return receiptsMatchingProductId
+    }
+    
+    /**
+     *  Get all the receipts info for a specific product from latest receipt info
+     *  - Parameter productId: the product id
+     *  - Parameter inReceipt: the receipt to grab info from
+     */
+    private class func getReceiptsInfoForSubscriptions(
+        forProductId productId: String,
+        inReceipt receipt: ReceiptInfo
+        ) -> [ReceiptInfo] {
+        // Get all latest receipt info
+        guard let latestInfoReceipts = receipt["latest_receipt_info"] as? [ReceiptInfo] else {
+            return []
+        }
+        
+        // Filter receipt infos with matching product id
+        let receiptsMatchingProductId = latestInfoReceipts
+            .filter { (receipt) -> Bool in
+                let product_id = receipt["product_id"] as? String
+                return product_id == productId
+        }
+        
         return receiptsMatchingProductId
     }
 }


### PR DESCRIPTION
Verifying subscription check ["latest_receipt_info"] section instead
["receipt"]["in_app"]

//
I do pull request for first time, hope did all correct.

I think you should check latest_receipt_info section instead in_app, because this sections refresh every time you do receipt verification on iTunes server. in_app section doesn’t refresh guaranteed. 100% it refresh only if u perform receipt refresh.