### PR TITLE
Enabled InAppReceiptRefreshRequest for macOS as it is supported

### DIFF
--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -219,8 +219,6 @@ extension ViewController {
                     return alertWithTitle("Purchase failed", message: "Unknown error. Please contact support")
                 case .invalidProductId(let productId):
                     return alertWithTitle("Purchase failed", message: "\(productId) is not a valid product identifier")
-                case .noProductIdentifier:
-                    return alertWithTitle("Purchase failed", message: "Product not found")
                 case .paymentNotAllowed:
                     return alertWithTitle("Payments not enabled", message: "You are not allowed to make payments")
             }

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -207,8 +207,6 @@ extension ViewController {
                 return alertWithTitle("Purchase failed", message: "Unknown error. Please contact support")
             case .invalidProductId(let productId):
                 return alertWithTitle("Purchase failed", message: "\(productId) is not a valid product identifier")
-            case .noProductIdentifier:
-                return alertWithTitle("Purchase failed", message: "Product not found")
             case .paymentNotAllowed:
                 return alertWithTitle("Payments not enabled", message: "You are not allowed to make payments")
             }

--- a/SwiftyStoreKit/InAppProductPurchaseRequest.swift
+++ b/SwiftyStoreKit/InAppProductPurchaseRequest.swift
@@ -78,11 +78,6 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
     
     // MARK: Private methods
     private func startPayment(_ product: SKProduct, applicationUsername: String = "") {
-        guard let _ = product._productIdentifier else {
-            let error = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: "Missing product identifier" ])
-            callback([TransactionResult.failed(error: error)])
-            return
-        }
         let payment = SKMutablePayment(product: product)
         payment.applicationUsername = applicationUsername
         
@@ -107,7 +102,7 @@ class InAppProductPurchaseRequest: NSObject, SKPaymentTransactionObserver {
             let transactionProductIdentifier = transaction.payment.productIdentifier
             
             var isPurchaseRequest = false
-            if let productIdentifier = product?._productIdentifier {
+            if let productIdentifier = product?.productIdentifier {
                 if transactionProductIdentifier != productIdentifier {
                     continue
                 }

--- a/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
+++ b/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
@@ -26,53 +26,51 @@
 import StoreKit
 import Foundation
 
-#if os(iOS) || os(tvOS)
-    class InAppReceiptRefreshRequest: NSObject, SKRequestDelegate {
-
-        enum ResultType {
-            case success
-            case error(e: Error)
-        }
-
-        typealias RequestCallback = (ResultType) -> ()
-
-        class func refresh(_ receiptProperties: [String : AnyObject]? = nil, callback: @escaping RequestCallback) -> InAppReceiptRefreshRequest {
-            let request = InAppReceiptRefreshRequest(receiptProperties: receiptProperties, callback: callback)
-            request.start()
-            return request
-        }
-
-        let refreshReceiptRequest: SKReceiptRefreshRequest
-        let callback: RequestCallback
-
-        deinit {
-            refreshReceiptRequest.delegate = nil
-        }
-
-        private init(receiptProperties: [String : AnyObject]? = nil, callback: @escaping RequestCallback) {
-            self.callback = callback
-            self.refreshReceiptRequest = SKReceiptRefreshRequest(receiptProperties: receiptProperties)
-            super.init()
-            self.refreshReceiptRequest.delegate = self
-        }
-
-        func start() {
-            self.refreshReceiptRequest.start()
-        }
-
-        func requestDidFinish(_ request: SKRequest) {
-            /*if let resoreRequest = request as? SKReceiptRefreshRequest {
-                let receiptProperties = resoreRequest.receiptProperties ?? [:]
-                for (k, v) in receiptProperties {
-                    print("\(k): \(v)")
-                }
-            }*/
-            callback(.success)
-        }
-        func request(_ request: SKRequest, didFailWithError error: Error) {
-            // XXX could here check domain and error code to return typed exception
-            callback(.error(e: error))
-        }
-        
+class InAppReceiptRefreshRequest: NSObject, SKRequestDelegate {
+    
+    enum ResultType {
+        case success
+        case error(e: Error)
     }
-#endif
+    
+    typealias RequestCallback = (ResultType) -> ()
+    
+    class func refresh(_ receiptProperties: [String : AnyObject]? = nil, callback: @escaping RequestCallback) -> InAppReceiptRefreshRequest {
+        let request = InAppReceiptRefreshRequest(receiptProperties: receiptProperties, callback: callback)
+        request.start()
+        return request
+    }
+    
+    let refreshReceiptRequest: SKReceiptRefreshRequest
+    let callback: RequestCallback
+    
+    deinit {
+        refreshReceiptRequest.delegate = nil
+    }
+    
+    private init(receiptProperties: [String : AnyObject]? = nil, callback: @escaping RequestCallback) {
+        self.callback = callback
+        self.refreshReceiptRequest = SKReceiptRefreshRequest(receiptProperties: receiptProperties)
+        super.init()
+        self.refreshReceiptRequest.delegate = self
+    }
+    
+    func start() {
+        self.refreshReceiptRequest.start()
+    }
+    
+    func requestDidFinish(_ request: SKRequest) {
+        /*if let resoreRequest = request as? SKReceiptRefreshRequest {
+         let receiptProperties = resoreRequest.receiptProperties ?? [:]
+         for (k, v) in receiptProperties {
+         print("\(k): \(v)")
+         }
+         }*/
+        callback(.success)
+    }
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        // XXX could here check domain and error code to return typed exception
+        callback(.error(e: error))
+    }
+    
+}

--- a/SwiftyStoreKit/OS.swift
+++ b/SwiftyStoreKit/OS.swift
@@ -29,25 +29,7 @@ import StoreKit
     extension SKMutablePayment {
         convenience init(product: SKProduct) {
             self.init()
-            self.productIdentifier = product._productIdentifier! // unsafe
+            self.productIdentifier = product.productIdentifier
         }
     }
 #endif
-
-// MARK: - product identifier optional on OSX, not on iOS
-
-extension SKProduct {
-    var _productIdentifier: String? {
-        return self.productIdentifier
-    }
-}
-
-// MARK: - products is optional on OSX, not on iOS
-extension SKProductsResponse {
-    var _products: [SKProduct]? {
-        return self.products
-    }
-    var _invalidProductIdentifiers: [String]? {
-        return self.invalidProductIdentifiers
-    }
-}

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -53,7 +53,6 @@ public struct RetrieveResults {
 public enum PurchaseError {
     case failed(error: Error)
     case invalidProductId(productId: String)
-    case noProductIdentifier
     case paymentNotAllowed
 }
 


### PR DESCRIPTION
- Also productIdentifier is not optional on macOS with Swift 3 so I removed that workaround code