### PR TITLE
Use receipt["latest_receipt_info"] when verifying subscriptions

### DIFF
--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -162,12 +162,12 @@ internal class InAppReceipt {
      */
     private class func filterReceiptsInfo(receipts: [ReceiptInfo]?, withProductId productId: String) -> [ReceiptInfo] {
 
-        guard let allReceipts = receipts else {
+        guard let receipts = receipts else {
             return []
         }
       
         // Filter receipts with matching product id
-        let receiptsMatchingProductId = allReceipts
+        let receiptsMatchingProductId = receipts
             .filter { (receipt) -> Bool in
                 let product_id = receipt["product_id"] as? String
                 return product_id == productId


### PR DESCRIPTION
Reference page:

https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html

Quoting:

> latest_receipt_info: Only returned for iOS 6 style transaction receipts for auto-renewable subscriptions. The JSON representation of the receipt for the most recent renewal.

> The values of the latest_receipt and latest_receipt_info keys are useful when checking whether an auto-renewable subscription is currently active. By providing any transaction receipt for the subscription and checking these values, you can get information about the currently-active subscription period. If the receipt being validated is for the latest renewal, the value for latest_receipt is the same as receipt-data (in the request) and the value for latest_receipt_info is the same as receipt.

