### PR TITLE
Feature/improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,16 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
     case .success(let product):
         print("Purchase Success: \(product.productId)")
     case .error(let error):
-        print("Purchase Failed: \(error)")
+        switch error.code {
+        case .unknown: print("Unknown error. Please contact support")
+        case .clientInvalid: print("Not allowed to make the payment")
+        case .paymentCancelled: break
+        case .paymentInvalid: print("The purchase identifier was invalid")
+        case .paymentNotAllowed: print("The device is not allowed to make the payment")
+        case .storeProductNotAvailable: print("The product is not available in the current storefront")
+        case .cloudServicePermissionDenied: print("Access to cloud service information is not allowed")
+        case .cloudServiceNetworkConnectionFailed: print("Could not connect to the network")
+        }
     }
 }
 ```
@@ -93,7 +102,16 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
         }
         print("Purchase Success: \(product.productId)")
     case .error(let error):
-        print("Purchase Failed: \(error)")
+        switch error.code {
+        case .unknown: print("Unknown error. Please contact support")
+        case .clientInvalid: print("Not allowed to make the payment")
+        case .paymentCancelled: break
+        case .paymentInvalid: print("The purchase identifier was invalid")
+        case .paymentNotAllowed: print("The device is not allowed to make the payment")
+        case .storeProductNotAvailable: print("The product is not available in the current storefront")
+        case .cloudServicePermissionDenied: print("Access to cloud service information is not allowed")
+        case .cloudServiceNetworkConnectionFailed: print("Could not connect to the network")
+        }
     }
 }
 ```
@@ -213,7 +231,7 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
         case .notPurchased:
             print("The user has never purchased this product")
         }
-    case .Error(let error):
+    case .error(let error):
         print("Receipt verification failed: \(error)")
     }
 }

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -215,29 +215,22 @@ extension ViewController {
             return alertWithTitle("Thank You", message: "Purchase completed")
         case .error(let error):
             print("Purchase Failed: \(error)")
-            switch error {
-                case .failed(let error):
-                    switch error.code {
-                    case .unknown: return alertWithTitle("Purchase failed", message: "Unknown error. Please contact support")
-                    case .clientInvalid: // client is not allowed to issue the request, etc.
-                        return alertWithTitle("Purchase failed", message: "Not allowed to make the payment")
-                    case .paymentCancelled: // user cancelled the request, etc.
-                        return nil
-                    case .paymentInvalid: // purchase identifier was invalid, etc.
-                        return alertWithTitle("Purchase failed", message: "The purchase identifier was invalid")
-                    case .paymentNotAllowed: // this device is not allowed to make the payment
-                        return alertWithTitle("Purchase failed", message: "The device is not allowed to make the payment")
-                    case .storeProductNotAvailable: // Product is not available in the current storefront
-                        return alertWithTitle("Purchase failed", message: "The product is not available in the current storefront")
-                    case .cloudServicePermissionDenied: // user has not allowed access to cloud service information
-                        return alertWithTitle("Purchase failed", message: "Access to cloud service information is not allowed")
-                    case .cloudServiceNetworkConnectionFailed: // the device could not connect to the nework
-                        return alertWithTitle("Purchase failed", message: "Could not connect to the network")
-                    }
-                case .invalidProductId(let productId):
-                    return alertWithTitle("Purchase failed", message: "\(productId) is not a valid product identifier")
-                case .paymentNotAllowed:
-                    return alertWithTitle("Payments not enabled", message: "You are not allowed to make payments")
+            switch error.code {
+            case .unknown: return alertWithTitle("Purchase failed", message: "Unknown error. Please contact support")
+            case .clientInvalid: // client is not allowed to issue the request, etc.
+                return alertWithTitle("Purchase failed", message: "Not allowed to make the payment")
+            case .paymentCancelled: // user cancelled the request, etc.
+                return nil
+            case .paymentInvalid: // purchase identifier was invalid, etc.
+                return alertWithTitle("Purchase failed", message: "The purchase identifier was invalid")
+            case .paymentNotAllowed: // this device is not allowed to make the payment
+                return alertWithTitle("Purchase failed", message: "The device is not allowed to make the payment")
+            case .storeProductNotAvailable: // Product is not available in the current storefront
+                return alertWithTitle("Purchase failed", message: "The product is not available in the current storefront")
+            case .cloudServicePermissionDenied: // user has not allowed access to cloud service information
+                return alertWithTitle("Purchase failed", message: "Access to cloud service information is not allowed")
+            case .cloudServiceNetworkConnectionFailed: // the device could not connect to the nework
+                return alertWithTitle("Purchase failed", message: "Could not connect to the network")
             }
         }
     }

--- a/SwiftyStoreKit.podspec
+++ b/SwiftyStoreKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SwiftyStoreKit'
-  s.version      = '0.7.1'
+  s.version      = '0.8.0'
   s.summary      = 'Lightweight In App Purchases Swift framework for iOS 8.0+, tvOS 9.0+ and OSX 10.10+'
   s.license      = 'MIT'
   s.homepage     = 'https://github.com/bizz84/SwiftyStoreKit'

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -38,7 +38,7 @@ protocol TransactionController {
 public enum TransactionResult {
     case purchased(product: Product)
     case restored(product: Product)
-    case failed(error: Error)
+    case failed(error: SKError)
 }
 
 public protocol PaymentQueue: class {

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -87,9 +87,7 @@ class PaymentsController: TransactionController {
         }
         if transactionState == .failed {
 
-            let message = "Transaction failed for product ID: \(transactionProductIdentifier)"
-            let altError = NSError(domain: SKErrorDomain, code: 0, userInfo: [ NSLocalizedDescriptionKey: message ])
-            payment.callback(.failed(error: transaction.error ?? altError))
+            payment.callback(.failed(error: transactionError(for: transaction.error as NSError?)))
             
             paymentQueue.finishTransaction(transaction)
             payments.remove(at: paymentIndex)
@@ -102,6 +100,13 @@ class PaymentsController: TransactionController {
         return false
     }
     
+    func transactionError(for error: NSError?) -> SKError {
+        let message = "Unknown error"
+        let altError = NSError(domain: SKErrorDomain, code: SKError.Code.unknown.rawValue, userInfo: [ NSLocalizedDescriptionKey: message ])
+        let nsError = error ?? altError
+        return SKError(_nsError: nsError)
+    }
+        
     func processTransactions(_ transactions: [SKPaymentTransaction], on paymentQueue: PaymentQueue) -> [SKPaymentTransaction] {
         
         return transactions.filter { !processTransaction($0, on: paymentQueue) }

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -102,7 +102,7 @@ class PaymentsController: TransactionController {
     
     func transactionError(for error: NSError?) -> SKError {
         let message = "Unknown error"
-        let altError = NSError(domain: SKErrorDomain, code: SKError.Code.unknown.rawValue, userInfo: [ NSLocalizedDescriptionKey: message ])
+        let altError = NSError(domain: SKErrorDomain, code: SKError.unknown.rawValue, userInfo: [ NSLocalizedDescriptionKey: message ])
         let nsError = error ?? altError
         return SKError(_nsError: nsError)
     }

--- a/SwiftyStoreKit/RestorePurchasesController.swift
+++ b/SwiftyStoreKit/RestorePurchasesController.swift
@@ -84,7 +84,7 @@ class RestorePurchasesController: TransactionController {
         guard let restorePurchases = restorePurchases else {
             return
         }
-        restoredProducts.append(.failed(error: error))
+        restoredProducts.append(.failed(error: SKError(_nsError: error as NSError)))
         restorePurchases.callback(restoredProducts)
         
         // Reset state after error received

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -54,23 +54,16 @@ public struct RetrieveResults {
     public let error: Error?
 }
 
-// Purchase error types
-public enum PurchaseError {
-    case failed(error: SKError)
-    case invalidProductId(productId: String)
-    case paymentNotAllowed
-}
-
 // Purchase result
 public enum PurchaseResult {
     case success(product: Product)
-    case error(error: PurchaseError)
+    case error(error: SKError)
 }
 
 // Restore purchase results
 public struct RestoreResults {
     public let restoredProducts: [Product]
-    public let restoreFailedProducts: [(Swift.Error, String?)]
+    public let restoreFailedProducts: [(SKError, String?)]
 }
 
 // MARK: Receipt verification

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -56,7 +56,7 @@ public struct RetrieveResults {
 
 // Purchase error types
 public enum PurchaseError {
-    case failed(error: Error)
+    case failed(error: SKError)
     case invalidProductId(productId: String)
     case paymentNotAllowed
 }

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -61,7 +61,7 @@ public class SwiftyStoreKit {
                     self.purchase(product: product, atomically: atomically, applicationUsername: applicationUsername, completion: completion)
                 }
                 else if let error = result.error {
-                    completion(.error(error: .failed(error: error)))
+                    completion(.error(error: .failed(error: SKError(_nsError: error as NSError))))
                 }
                 else if let invalidProductId = result.invalidProductIDs.first {
                     completion(.error(error: .invalidProductId(productId: invalidProductId)))
@@ -128,7 +128,7 @@ public class SwiftyStoreKit {
         case .failed(let error):
             return .error(error: .failed(error: error))
         case .restored(let product):
-            return .error(error: .failed(error: storeInternalError(code: InternalErrorCode.restoredPurchaseWhenPurchasing.rawValue, description: "Cannot restore product \(product.productId) from purchase path")))
+            return .error(error: .failed(error: SKError(_nsError:  storeInternalError(code: InternalErrorCode.restoredPurchaseWhenPurchasing.rawValue, description: "Cannot restore product \(product.productId) from purchase path"))))
         }
     }
     

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -60,7 +60,7 @@ public class SwiftyStoreKit {
                 }
                 else if let invalidProductId = result.invalidProductIDs.first {
                     let userInfo = [ NSLocalizedDescriptionKey: "Invalid product id: \(invalidProductId)" ]
-                    let error = NSError(domain: SKErrorDomain, code: SKError.storeProductNotAvailable.rawValue, userInfo: userInfo)
+                    let error = NSError(domain: SKErrorDomain, code: SKError.paymentInvalid.rawValue, userInfo: userInfo)
                     completion(.error(error: SKError(_nsError: error)))
                 }
             }


### PR DESCRIPTION
This PR streamlines error handling. See related issue: https://github.com/bizz84/SwiftyStoreKit/issues/122

This makes it much easier to check all possible errors that can happen during a purchase:

- [x] `clientInvalid`: Not allowed to make the payment
- [x] `paymentCancelled`: The user has cancelled the payment
- [x] `paymentInvalid`: The purchase identifier was invalid
- [x] `paymentNotAllowed`: In-app purchases have been disabled for the device
- [x] `storeProductNotAvailable`: The product is not available in the current storefront
- [x] `cloudServicePermissionDenied`: Access to cloud service information is not allowed
- [x] `cloudServiceNetworkConnectionFailed`: Could not connect to the network
- [x] `unknown`: anything else

This is in line with: https://developer.apple.com/reference/storekit/skerror.code

This is an API breaking change as the `PurchaseError` type has been removed in favour of `SKError`. Clients can now make purchases and check errors like this:

```swift
SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomically: true) { result in
    switch result {
    case .success(let product):
        print("Purchase Success: \(product.productId)")
    case .error(let error):
        switch error.code {
        case .unknown: print("Unknown error. Please contact support")
        case .clientInvalid: print("Not allowed to make the payment")
        case .paymentCancelled: break
        case .paymentInvalid: print("The purchase identifier was invalid")
        case .paymentNotAllowed: print("The device is not allowed to make the payment")
        case .storeProductNotAvailable: print("The product is not available in the current storefront")
        case .cloudServicePermissionDenied: print("Access to cloud service information is not allowed")
        case .cloudServiceNetworkConnectionFailed: print("Could not connect to the network")
        }
    }
}
```
