### PR TITLE
Fixes calls to canMakePayments() 

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -43,6 +43,8 @@ public enum TransactionResult {
 
 public protocol PaymentQueue: class {
 
+    static func canMakePayments() -> Bool
+    
     func add(_ observer: SKPaymentTransactionObserver)
     func remove(_ observer: SKPaymentTransactionObserver)
 

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -28,7 +28,7 @@ public class SwiftyStoreKit {
 
     private let productsInfoController: ProductsInfoController
 
-    private let paymentQueueController: PaymentQueueController
+    fileprivate let paymentQueueController: PaymentQueueController
     
     private var receiptRefreshRequest: InAppReceiptRefreshRequest?
     
@@ -160,7 +160,7 @@ extension SwiftyStoreKit {
     
     // MARK: Public methods - Purchases
     public class var canMakePayments: Bool {
-        return SKPaymentQueue.canMakePayments()
+        return type(of: sharedInstance.paymentQueueController.paymentQueue).canMakePayments()
     }
 
     public class func retrieveProductsInfo(_ productIds: Set<String>, completion: @escaping (RetrieveResults) -> ()) {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -107,7 +107,7 @@ public class SwiftyStoreKit {
 
     // MARK: private methods
     private func purchase(product: SKProduct, atomically: Bool, applicationUsername: String = "", completion: @escaping (PurchaseResult) -> ()) {
-        guard SwiftyStoreKit.canMakePayments else {
+        guard type(of: paymentQueueController.paymentQueue).canMakePayments() else {
             let error = NSError(domain: SKErrorDomain, code: SKError.paymentNotAllowed.rawValue, userInfo: nil)
             completion(.error(error: SKError(_nsError: error)))
             return


### PR DESCRIPTION
Since SwiftyStoreKit injects the PaymentQueueController and its PaymentQueue via it's constructor, calls to canMakePayments() must use the injected instance of the payment queue.

This PR makes changes to ensure canMakePayments() is invoked from the injected payment queue  instead of assuming SKPaymentQueue as the default.