### PR TITLE
Don't call completeTransactions callback if there aren't any transactions to process

### DIFF
--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -67,7 +67,9 @@ class CompleteTransactionsController: TransactionController {
                 unhandledTransactions.append(transaction)
             }
         }
-        completeTransactions.callback(products)
+        if products.count > 0 {
+            completeTransactions.callback(products)
+        }
 
         return unhandledTransactions
     }


### PR DESCRIPTION
See #149 