### PR TITLE
Additional logging to clarify intended usage of `completeTransactions()`

### DIFF
--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -42,6 +42,7 @@ class CompleteTransactionsController: TransactionController {
     func processTransactions(_ transactions: [SKPaymentTransaction], on paymentQueue: PaymentQueue) -> [SKPaymentTransaction] {
 
         guard let completeTransactions = completeTransactions else {
+            print("SwiftyStoreKit.completeTransactions() should be called once when the app launches.")
             return transactions
         }
 

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -125,6 +125,11 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
     }
 
     func completeTransactions(_ completeTransactions: CompleteTransactions) {
+        
+        guard completeTransactionsController.completeTransactions == nil else {
+            print("SwiftyStoreKit.completeTransactions() should only be called once when the app launches. Ignoring this call")
+            return
+        }
 
         completeTransactionsController.completeTransactions = completeTransactions
     }


### PR DESCRIPTION
Added two console logs to remind the user to:

* call `completeTransactions()` when the app launches
* call it only once

See #146 