### PR TITLE
Add SubscriptionType to differentiate between auto-renewable and non-renewing subscriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
         // Verify the purchase of Consumable or NonConsumable
         let purchaseResult = SwiftyStoreKit.verifyPurchase(
             productId: "com.musevisions.SwiftyStoreKit.Purchase1",
-            inReceipt: receipt
-        )
+            inReceipt: receipt)
+            
         switch purchaseResult {
         case .purchased(let expiresDate):
             print("Product is purchased.")
@@ -250,11 +250,10 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
     case .success(let receipt):
         // Verify the purchase of a Subscription
         let purchaseResult = SwiftyStoreKit.verifySubscription(
+            type: .autoRenewable, // or .nonRenewing (see below)
             productId: "com.musevisions.SwiftyStoreKit.Subscription",
-            inReceipt: receipt,
-            validUntil: NSDate(),
-            validDuration: 3600 * 24 * 30 // Non Renewing Subscription only
-        )
+            inReceipt: receipt)
+            
         switch purchaseResult {
         case .purchased(let expiresDate):
             print("Product is valid until \(expiresDate)")
@@ -270,9 +269,21 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
 }
 ```
 
+#### Auto-Renewable
+```
+let purchaseResult = SwiftyStoreKit.verifySubscription(
+            type: .autoRenewable,
+            productId: "com.musevisions.SwiftyStoreKit.Subscription",
+            inReceipt: receipt)
+```
 
-To test the expiration of a Non Renewing Subscription, you must indicate the `validDuration` time interval in seconds.
-
+#### Non-Renewing
+```
+let purchaseResult = SwiftyStoreKit.verifySubscription(
+            type: .nonRenewing(validDuration: 3600 * 24 * 30),
+            productId: "com.musevisions.SwiftyStoreKit.Subscription",
+            inReceipt: receipt)
+```
 
 
 **NOTE**:

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -136,15 +136,24 @@ class ViewController: UIViewController {
 
                 let productId = self.appBundleId + "." + purchase.rawValue
 
-                // Specific behaviour for AutoRenewablePurchase
-                if purchase == .autoRenewablePurchase {
+                switch purchase {
+                case .autoRenewablePurchase:
                     let purchaseResult = SwiftyStoreKit.verifySubscription(
+                        type: .autoRenewable,
                         productId: productId,
                         inReceipt: receipt,
                         validUntil: Date()
                     )
                     self.showAlert(self.alertForVerifySubscription(purchaseResult))
-                } else {
+                case .nonRenewingPurchase:
+                    let purchaseResult = SwiftyStoreKit.verifySubscription(
+                        type: .nonRenewing(validDuration: 60),
+                        productId: productId,
+                        inReceipt: receipt,
+                        validUntil: Date()
+                    )
+                    self.showAlert(self.alertForVerifySubscription(purchaseResult))
+                default:
                     let purchaseResult = SwiftyStoreKit.verifyPurchase(
                         productId: productId,
                         inReceipt: receipt

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -131,15 +131,22 @@ class ViewController: NSViewController {
 
                 let productId = self.appBundleId + "." + purchase.rawValue
 
-                // Specific behaviour for AutoRenewablePurchase
-                if purchase == .autoRenewablePurchase {
+                switch purchase {
+                case .autoRenewablePurchase:
                     let purchaseResult = SwiftyStoreKit.verifySubscription(
+                        type: .autoRenewable,
                         productId: productId,
-                        inReceipt: receipt,
-                        validUntil: Date()
+                        inReceipt: receipt
                     )
                     self.showAlert(self.alertForVerifySubscription(purchaseResult))
-                } else {
+                case .nonRenewingPurchase:
+                    let purchaseResult = SwiftyStoreKit.verifySubscription(
+                        type: .nonRenewing(validDuration: 60),
+                        productId: productId,
+                        inReceipt: receipt
+                    )
+                    self.showAlert(self.alertForVerifySubscription(purchaseResult))
+                default:
                     let purchaseResult = SwiftyStoreKit.verifyPurchase(
                         productId: productId,
                         inReceipt: receipt

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -96,6 +96,11 @@ public enum VerifySubscriptionResult {
     case notPurchased
 }
 
+public enum SubscriptionType {
+    case autoRenewable
+    case nonRenewing(validDuration: TimeInterval)
+}
+
 // Error when managing receipt
 public enum ReceiptError: Swift.Error {
     // No receipt data

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -250,11 +250,11 @@ extension SwiftyStoreKit {
      *  - return: either NotPurchased or Purchased / Expired with the expiry date found in the receipt
      */
     public class func verifySubscription(
+        type: SubscriptionType,
         productId: String,
         inReceipt receipt: ReceiptInfo,
-        validUntil date: Date = Date(),
-        validDuration duration: TimeInterval? = nil
+        validUntil date: Date = Date()
         ) -> VerifySubscriptionResult {
-        return InAppReceipt.verifySubscription(productId: productId, inReceipt: receipt, validUntil: date, validDuration: duration)
+        return InAppReceipt.verifySubscription(type: type, productId: productId, inReceipt: receipt, validUntil: date)
     }
 }


### PR DESCRIPTION
For auto-renewable, `receipt["latest_receipt_info"]` is used.
For non-renewing, `receipt["receipt"]?["in_app"]` is used.

This fixes a bug where receipt verification fails for non-renewing subscriptions (which were previously using `"latest_receipt_info"`.