### PR TITLE
Filter out all receipts with "cancellation_date" != nil (#163)

### DIFF
--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -105,14 +105,15 @@ internal class InAppReceipt {
         // The values of the latest_receipt and latest_receipt_info keys are useful when checking whether an auto-renewable subscription is currently active. By providing any transaction receipt for the subscription and checking these values, you can get information about the currently-active subscription period. If the receipt being validated is for the latest renewal, the value for latest_receipt is the same as receipt-data (in the request) and the value for latest_receipt_info is the same as receipt.
         let (receipts, duration) = getReceiptsAndDuration(for: type, inReceipt: receipt)
         let receiptsInfo = filterReceiptsInfo(receipts: receipts, withProductId: productId)
-        if receiptsInfo.count == 0 {
+        let nonCancelledReceiptsInfo = receiptsInfo.filter { receipt in receipt["cancellation_date"] == nil }
+        if nonCancelledReceiptsInfo.count == 0 {
             return .notPurchased
         }
 
         let receiptDate = getReceiptRequestDate(inReceipt: receipt) ?? date
 
         // Return the expires dates sorted desc
-        let expiryDateValues = receiptsInfo
+        let expiryDateValues = nonCancelledReceiptsInfo
             .flatMap { (receipt) -> String? in
                 let key: String = duration != nil ? "original_purchase_date_ms" : "expires_date_ms"
                 return receipt[key] as? String


### PR DESCRIPTION
See #163. According to Apple docs:

> **Cancellation Date**
For a transaction that was canceled by Apple customer support, the time and date of the cancellation.
ASN.1 Field Type 1712
ASN.1 Field Value IA5STRING, interpreted as an RFC 3339 date
JSON Field Name cancellation_date
JSON Field Value string, interpreted as an RFC 3339 date
**Treat a canceled receipt the same as if no purchase had ever been made.**


https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html