### PR TITLE
Bump SwiftLint 0.17.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@
 # rule identifiers to exclude from running
 disabled_rules:
 - line_length
+- identifier_name
 
 # configurable rules can be customized from this configuration file
 line_length: 250

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SwiftyStoreKit.completeTransactions(atomically: true) { products in
 
             for product in products {
-
+                // swiftlint:disable:next for_where
                 if product.transaction.transactionState == .purchased || product.transaction.transactionState == .restored {
 
                     if product.needsFinishTransaction {

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -97,11 +97,9 @@ class ViewController: UIViewController {
         SwiftyStoreKit.restorePurchases(atomically: true) { results in
             NetworkActivityIndicatorManager.networkOperationFinished()
 
-            for product in results.restoredProducts {
+            for product in results.restoredProducts where product.needsFinishTransaction {
                 // Deliver content from server, then:
-                if product.needsFinishTransaction {
-                    SwiftyStoreKit.finishTransaction(product.transaction)
-                }
+                SwiftyStoreKit.finishTransaction(product.transaction)
             }
             self.showAlert(self.alertForRestorePurchases(results))
         }
@@ -196,7 +194,7 @@ extension ViewController {
     }
 
     func showAlert(_ alert: UIAlertController) {
-        guard let _ = self.presentedViewController else {
+        guard self.presentedViewController != nil else {
             self.present(alert, animated: true, completion: nil)
             return
         }

--- a/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
@@ -38,7 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         SwiftyStoreKit.completeTransactions(atomically: true) { products in
 
             for product in products {
-
+                // swiftlint:disable:next for_where
                 if product.transaction.transactionState == .purchased || product.transaction.transactionState == .restored {
 
                     if product.needsFinishTransaction {

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -94,11 +94,9 @@ class ViewController: NSViewController {
 
         SwiftyStoreKit.restorePurchases(atomically: true) { results in
 
-            for product in results.restoredProducts {
+            for product in results.restoredProducts where product.needsFinishTransaction {
                 // Deliver content from server, then:
-                if product.needsFinishTransaction {
-                    SwiftyStoreKit.finishTransaction(product.transaction)
-                }
+                SwiftyStoreKit.finishTransaction(product.transaction)
             }
 
             self.showAlert(self.alertForRestorePurchases(results))

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -44,10 +44,8 @@ class PaymentsController: TransactionController {
     private var payments: [Payment] = []
 
     private func findPaymentIndex(withProductIdentifier identifier: String) -> Int? {
-        for payment in payments {
-            if payment.product.productIdentifier == identifier {
-                return payments.index(of: payment)
-            }
+        for payment in payments where payment.product.productIdentifier == identifier {
+            return payments.index(of: payment)
         }
         return nil
     }

--- a/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
@@ -53,7 +53,7 @@ class PaymentQueueControllerTests: XCTestCase {
 
         let spy = PaymentQueueSpy()
 
-        let _ = PaymentQueueController(paymentQueue: spy)
+        _ = PaymentQueueController(paymentQueue: spy)
 
         XCTAssertNil(spy.observer)
     }

--- a/SwiftyStoreKitTests/PaymentsControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentsControllerTests.swift
@@ -79,7 +79,7 @@ class PaymentsControllerTests: XCTestCase {
         let payment = makeTestPayment(product: testProduct) { result in
 
             callbackCalled = true
-            if case .failed(_) = result {
+            if case .failed = result {
 
             } else {
                 XCTFail("expected failed callback with error")
@@ -124,7 +124,7 @@ class PaymentsControllerTests: XCTestCase {
         var callback2Called = false
         let payment2 = makeTestPayment(product: testProduct2) { result in
             callback2Called = true
-            if case .failed(_) = result {
+            if case .failed = result {
 
             } else {
                 XCTFail("expected failed callback with error")

--- a/SwiftyStoreKitTests/RestorePurchasesControllerTests.swift
+++ b/SwiftyStoreKitTests/RestorePurchasesControllerTests.swift
@@ -121,7 +121,7 @@ class RestorePurchasesControllerTests: XCTestCase {
 
             XCTAssertEqual(results.count, 1)
             let first = results.first!
-            if case .failed(_) = first {
+            if case .failed = first {
 
             } else {
                 XCTFail("expected failed callback with error")


### PR DESCRIPTION
otherwise, it won't build anymore with Carthage.

In this PR:
- Disabled `identifier_name` rules: since you have a few `a`, `b`, enabled that rule ask a few refactoring
- Fix warnings due to new rules in 0.17.0