### PR TITLE
Add ReceiptItem to VerifyPurchaseResult, VerifySubscriptionResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
             inReceipt: receipt)
             
         switch purchaseResult {
-        case .purchased(let expiresDate):
-            print("Product is purchased.")
+        case .purchased(let receiptItem):
+            print("Product is purchased: \(receiptItem)")
         case .notPurchased:
             print("The user has never purchased this product")
         }
@@ -263,13 +263,17 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
 }
 ```
 
-Note that for consumable products, the receipt will only include the information for a couples of minutes after the purchase.
+Note that for consumable products, the receipt will only include the information for a couple of minutes after the purchase.
 
 ### Verify Subscription
 
 This can be used to check if a subscription was previously purchased, and whether it is still active or if it's expired.
 
-If a subscription has been purchased multiple times, this method will return `.purchased` or `.expired` for the most recent one.
+From [Apple - Working with Subscriptions](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Subscriptions.html#//apple_ref/doc/uid/TP40008267-CH7-SW6):
+
+> keep a record of the date that each piece of content is published. Read the Original Purchase Date and Subscription Expiration Date field from each receipt entry to determine the start and end dates of the subscription.
+
+When one or more subscriptions are found for a given product id, they are returned as a `ReceiptItem` array ordered by `expiryDate`, with the first one being the newest.
 
 ```swift
 let appleValidator = AppleReceiptValidator(service: .production)
@@ -283,10 +287,10 @@ SwiftyStoreKit.verifyReceipt(using: appleValidator, password: "your-shared-secre
             inReceipt: receipt)
             
         switch purchaseResult {
-        case .purchased(let expiresDate):
-            print("Product is valid until \(expiresDate)")
-        case .expired(let expiresDate):
-            print("Product is expired since \(expiresDate)")
+        case .purchased(let expiryDate, let receiptItems):
+            print("Product is valid until \(expiryDate)")
+        case .expired(let expiryDate, let receiptItems):
+            print("Product is expired since \(expiryDate)")
         case .notPurchased:
             print("The user has never purchased this product")
         }
@@ -340,9 +344,9 @@ SwiftyStoreKit.purchaseProduct(productId, atomically: true) { result in
                     inReceipt: receipt)
                 
                 switch purchaseResult {
-                case .purchased(let expiryDate):
+                case .purchased(let expiryDate, let receiptItems):
                     print("Product is valid until \(expiryDate)")
-                case .expired(let expiryDate):
+                case .expired(let expiryDate, let receiptItems):
                     print("Product is expired since \(expiryDate)")
                 case .notPurchased:
                     print("This product has never been purchased")

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -182,10 +182,11 @@ internal class InAppReceipt {
             return .notPurchased
         }
 
+        let sortedReceiptItems = sortedExpiryDatesAndItems.map { $0.1 }
         if firstExpiryDateItemPair.0 > receiptDate {
-            return .purchased(expiryDate: firstExpiryDateItemPair.0, item: firstExpiryDateItemPair.1)
+            return .purchased(expiryDate: firstExpiryDateItemPair.0, items: sortedReceiptItems)
         } else {
-            return .expired(expiryDate: firstExpiryDateItemPair.0, item: firstExpiryDateItemPair.1)
+            return .expired(expiryDate: firstExpiryDateItemPair.0, items: sortedReceiptItems)
         }
     }
 

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -85,20 +85,43 @@ public enum VerifyReceiptResult {
 
 // Result for Consumable and NonConsumable
 public enum VerifyPurchaseResult {
-    case purchased
+    case purchased(item: ReceiptItem)
     case notPurchased
 }
 
 // Verify subscription result
 public enum VerifySubscriptionResult {
-    case purchased(expiryDate: Date)
-    case expired(expiryDate: Date)
+    case purchased(expiryDate: Date, item: ReceiptItem)
+    case expired(expiryDate: Date, item: ReceiptItem)
     case notPurchased
 }
 
 public enum SubscriptionType {
     case autoRenewable
     case nonRenewing(validDuration: TimeInterval)
+}
+
+public struct ReceiptItem {
+    // The product identifier of the item that was purchased. This value corresponds to the productIdentifier property of the SKPayment object stored in the transaction’s payment property.
+    public let productId: String
+    // The number of items purchased. This value corresponds to the quantity property of the SKPayment object stored in the transaction’s payment property.
+    public let quantity: Int
+    // The transaction identifier of the item that was purchased. This value corresponds to the transaction’s transactionIdentifier property.
+    public let transactionId: String
+    // For a transaction that restores a previous transaction, the transaction identifier of the original transaction. Otherwise, identical to the transaction identifier. This value corresponds to the original transaction’s transactionIdentifier property. All receipts in a chain of renewals for an auto-renewable subscription have the same value for this field.
+    public let originalTransactionId: String
+    // The date and time that the item was purchased. This value corresponds to the transaction’s transactionDate property.
+    public let purchaseDate: Date
+    // For a transaction that restores a previous transaction, the date of the original transaction. This value corresponds to the original transaction’s transactionDate property. In an auto-renewable subscription receipt, this indicates the beginning of the subscription period, even if the subscription has been renewed.
+    public let originalPurchaseDate: Date
+    // The primary key for identifying subscription purchases.
+    public let webOrderLineItemId: String
+    // The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT. This key is only present for auto-renewable subscription receipts.
+    public let subscriptionExpirationDate: Date?
+    // For a transaction that was canceled by Apple customer support, the time and date of the cancellation. Treat a canceled receipt the same as if no purchase had ever been made.
+    public let cancellationDate: Date?
+
+    public let isTrialPeriod: Bool
 }
 
 // Error when managing receipt

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -91,8 +91,8 @@ public enum VerifyPurchaseResult {
 
 // Verify subscription result
 public enum VerifySubscriptionResult {
-    case purchased(expiryDate: Date, item: ReceiptItem)
-    case expired(expiryDate: Date, item: ReceiptItem)
+    case purchased(expiryDate: Date, items: [ReceiptItem])
+    case expired(expiryDate: Date, items: [ReceiptItem])
     case notPurchased
 }
 

--- a/SwiftyStoreKitTests/InAppReceiptTests.swift
+++ b/SwiftyStoreKitTests/InAppReceiptTests.swift
@@ -169,7 +169,7 @@ class InAppReceiptTests: XCTestCase {
 
         let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .autoRenewable, productId: productId, inReceipt: receipt)
 
-        let expectedSubscriptionResult = VerifySubscriptionResult.expired(expiryDate: expirationDate, item: item)
+        let expectedSubscriptionResult = VerifySubscriptionResult.expired(expiryDate: expirationDate, items: [item])
         XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
     }
 
@@ -186,7 +186,7 @@ class InAppReceiptTests: XCTestCase {
 
         let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .autoRenewable, productId: productId, inReceipt: receipt)
 
-        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: expirationDate, item: item)
+        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: expirationDate, items: [item])
         XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
     }
 
@@ -236,7 +236,7 @@ class InAppReceiptTests: XCTestCase {
 
         let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .nonRenewing(validDuration: duration), productId: productId, inReceipt: receipt)
 
-        let expectedSubscriptionResult = VerifySubscriptionResult.expired(expiryDate: expirationDate, item: item)
+        let expectedSubscriptionResult = VerifySubscriptionResult.expired(expiryDate: expirationDate, items: [item])
         XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
     }
 
@@ -255,7 +255,7 @@ class InAppReceiptTests: XCTestCase {
 
         let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .nonRenewing(validDuration: duration), productId: productId, inReceipt: receipt)
 
-        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: expirationDate, item: item)
+        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: expirationDate, items: [item])
         XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
     }
 
@@ -278,7 +278,7 @@ class InAppReceiptTests: XCTestCase {
     }
 
     // MARK: Verify Subscription, multiple receipt item tests
-    func verifyAutoRenewableSubscription_when_twoSubscriptions_sameProductId_mostRecentNonExpired_then_resultIsPurchased() {
+    func verifyAutoRenewableSubscription_when_twoSubscriptions_sameProductId_mostRecentNonExpired_then_resultIsPurchased_itemsSorted() {
 
         let receiptRequestDate = makeDateAtMidnight(year: 2017, month: 5, day: 14)
 
@@ -305,7 +305,38 @@ class InAppReceiptTests: XCTestCase {
 
         let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .autoRenewable, productId: productId, inReceipt: receipt)
 
-        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: newerExpirationDate, item: newerItem)
+        let expectedSubscriptionResult = VerifySubscriptionResult.purchased(expiryDate: newerExpirationDate, items: [newerItem, olderItem])
+        XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
+    }
+
+    func verifyAutoRenewableSubscription_when_twoSubscriptions_sameProductId_bothExpired_then_resultIsExpired_itemsSorted() {
+        
+        let receiptRequestDate = makeDateAtMidnight(year: 2017, month: 5, day: 14)
+        
+        let productId = "product1"
+        let isTrialPeriod = false
+        
+        let olderPurchaseDate = makeDateAtMidnight(year: 2017, month: 5, day: 12)
+        let olderExpirationDate = olderPurchaseDate.addingTimeInterval(60 * 60)
+        let olderItem = ReceiptItem(productId: productId,
+                                    purchaseDate: olderPurchaseDate,
+                                    subscriptionExpirationDate: olderExpirationDate,
+                                    cancellationDate: nil,
+                                    isTrialPeriod: isTrialPeriod)
+        
+        let newerPurchaseDate = makeDateAtMidnight(year: 2017, month: 5, day: 13)
+        let newerExpirationDate = olderPurchaseDate.addingTimeInterval(60 * 60)
+        let newerItem = ReceiptItem(productId: productId,
+                                    purchaseDate: newerPurchaseDate,
+                                    subscriptionExpirationDate: newerExpirationDate,
+                                    cancellationDate: nil,
+                                    isTrialPeriod: isTrialPeriod)
+        
+        let receipt = makeReceipt(items: [olderItem, newerItem], requestDate: receiptRequestDate)
+        
+        let verifySubscriptionResult = SwiftyStoreKit.verifySubscription(type: .autoRenewable, productId: productId, inReceipt: receipt)
+        
+        let expectedSubscriptionResult = VerifySubscriptionResult.expired(expiryDate: newerExpirationDate, items: [newerItem, olderItem])
         XCTAssertEqual(verifySubscriptionResult, expectedSubscriptionResult)
     }
 


### PR DESCRIPTION
This PR introduces a new strong-typed `ReceiptItem` struct:

```swift
public struct ReceiptItem {
    // The product identifier of the item that was purchased. This value corresponds to the productIdentifier property of the SKPayment object stored in the transaction’s payment property.
    public let productId: String
    // The number of items purchased. This value corresponds to the quantity property of the SKPayment object stored in the transaction’s payment property.
    public let quantity: Int
    // The transaction identifier of the item that was purchased. This value corresponds to the transaction’s transactionIdentifier property.
    public let transactionId: String
    // For a transaction that restores a previous transaction, the transaction identifier of the original transaction. Otherwise, identical to the transaction identifier. This value corresponds to the original transaction’s transactionIdentifier property. All receipts in a chain of renewals for an auto-renewable subscription have the same value for this field.
    public let originalTransactionId: String
    // The date and time that the item was purchased. This value corresponds to the transaction’s transactionDate property.
    public let purchaseDate: Date
    // For a transaction that restores a previous transaction, the date of the original transaction. This value corresponds to the original transaction’s transactionDate property. In an auto-renewable subscription receipt, this indicates the beginning of the subscription period, even if the subscription has been renewed.
    public let originalPurchaseDate: Date
    // The primary key for identifying subscription purchases.
    public let webOrderLineItemId: String
    // The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT. This key is only present for auto-renewable subscription receipts.
    public let subscriptionExpirationDate: Date?
    // For a transaction that was canceled by Apple customer support, the time and date of the cancellation. Treat a canceled receipt the same as if no purchase had ever been made.
    public let cancellationDate: Date?

    public let isTrialPeriod: Bool
}
```

This is parsed from the receipt and returned as part of the `verifySubscription` and `verifyPurchase` methods:

```swift
// Result for Consumable and NonConsumable
public enum VerifyPurchaseResult {
    case purchased(item: ReceiptItem)
    case notPurchased
}

// Verify subscription result
public enum VerifySubscriptionResult {
    case purchased(expiryDate: Date, items: [ReceiptItem])
    case expired(expiryDate: Date, items: [ReceiptItem])
    case notPurchased
}
```

Note that when one or more subscriptions are found for a given product id, they are returned as a `ReceiptItem` array ordered by `expiryDate`, with the first one being the newest.

This is useful to get all the valid date ranges for a given subscription.

This PR is a superset of #192 and #190.
