### PR TITLE
Feature/rename product to payment with quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ SwiftyStoreKit supports this by calling `completeTransactions()` when the app st
 ```swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 
-	SwiftyStoreKit.completeTransactions(atomically: true) { products in
+	SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 	
-	    for product in products {
+	    for purchase in purchases {
 	
-	        if product.transaction.transactionState == .purchased || product.transaction.transactionState == .restored {
+	        if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
 	
-               if product.needsFinishTransaction {
+               if purchase.needsFinishTransaction {
                    // Deliver content from server, then:
-                   SwiftyStoreKit.finishTransaction(product.transaction)
+                   SwiftyStoreKit.finishTransaction(purchase.transaction)
                }
-               print("purchased: \(product)")
+               print("purchased: \(purchase)")
 	        }
 	    }
 	}
@@ -79,10 +79,10 @@ SwiftyStoreKit.retrieveProductsInfo(["com.musevisions.SwiftyStoreKit.Purchase1"]
 * **Atomic**: to be used when the content is delivered immediately.
 
 ```swift
-SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomically: true) { result in
+SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", quantity: 1, atomically: true) { result in
     switch result {
-    case .success(let product):
-        print("Purchase Success: \(product.productId)")
+    case .success(let purchase):
+        print("Purchase Success: \(purchase.productId)")
     case .error(let error):
         switch error.code {
         case .unknown: print("Unknown error. Please contact support")
@@ -93,6 +93,7 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
         case .storeProductNotAvailable: print("The product is not available in the current storefront")
         case .cloudServicePermissionDenied: print("Access to cloud service information is not allowed")
         case .cloudServiceNetworkConnectionFailed: print("Could not connect to the network")
+        case .cloudServiceRevoked: print("User has revoked permission to use this cloud service")
         }
     }
 }
@@ -101,7 +102,7 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
 * **Non-Atomic**: to be used when the content is delivered by the server.
 
 ```swift
-SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomically: false) { result in
+SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", quantity: 1, atomically: false) { result in
     switch result {
     case .success(let product):
         // fetch content from your server, then:
@@ -119,6 +120,7 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
         case .storeProductNotAvailable: print("The product is not available in the current storefront")
         case .cloudServicePermissionDenied: print("Access to cloud service information is not allowed")
         case .cloudServiceNetworkConnectionFailed: print("Could not connect to the network")
+        case .cloudServiceRevoked: print("User has revoked permission to use this cloud service")
         }
     }
 }
@@ -130,11 +132,11 @@ SwiftyStoreKit.purchaseProduct("com.musevisions.SwiftyStoreKit.Purchase1", atomi
 
 ```swift
 SwiftyStoreKit.restorePurchases(atomically: true) { results in
-    if results.restoreFailedProducts.count > 0 {
-        print("Restore Failed: \(results.restoreFailedProducts)")
+    if results.restoreFailedPurchases.count > 0 {
+        print("Restore Failed: \(results.restoreFailedPurchases)")
     }
-    else if results.restoredProducts.count > 0 {
-        print("Restore Success: \(results.restoredProducts)")
+    else if results.restoredPurchases.count > 0 {
+        print("Restore Success: \(results.restoredPurchases")
     }
     else {
         print("Nothing to Restore")
@@ -146,17 +148,17 @@ SwiftyStoreKit.restorePurchases(atomically: true) { results in
 
 ```swift
 SwiftyStoreKit.restorePurchases(atomically: false) { results in
-    if results.restoreFailedProducts.count > 0 {
-        print("Restore Failed: \(results.restoreFailedProducts)")
+    if results.restoreFailedPurchases.count > 0 {
+        print("Restore Failed: \(results.restoreFailedPurchases)")
     }
-    else if results.restoredProducts.count > 0 {
-        for product in results.restoredProducts {
+    else if results.restoredPurchases.count > 0 {
+        for purchase in results.restoredPurchases {
             // fetch content from your server, then:
-            if product.needsFinishTransaction {
-                SwiftyStoreKit.finishTransaction(product.transaction)
+            if purchase.needsFinishTransaction {
+                SwiftyStoreKit.finishTransaction(purchase.transaction)
             }
         }
-        print("Restore Success: \(results.restoredProducts)")
+        print("Restore Success: \(results.restoredPurchases)")
     }
     else {
         print("Nothing to Restore")
@@ -171,13 +173,13 @@ When you purchase a product the following things happen:
 * A payment is added to the payment queue for your IAP.
 * When the payment has been processed with Apple, the payment queue is updated so that the appropriate transaction can be handled.
 * If the transaction state is **purchased** or **restored**, the app can unlock the functionality purchased by the user.
-* The app should call `finishTransaction()` to complete the purchase.
+* The app should call `finishTransaction(_:)` to complete the purchase.
 
 This is what is [recommended by Apple](https://developer.apple.com/reference/storekit/skpaymentqueue/1506003-finishtransaction):
 
-> Your application should call finishTransaction(_:) only after it has successfully processed the transaction and unlocked the functionality purchased by the user.
+> Your application should call `finishTransaction(_:)` only after it has successfully processed the transaction and unlocked the functionality purchased by the user.
 
-* A purchase is **atomic** when the app unlocks the functionality purchased by the user immediately and call `finishTransaction()` at the same time. This is desirable if you're unlocking functionality that is already inside the app.
+* A purchase is **atomic** when the app unlocks the functionality purchased by the user immediately and call `finishTransaction(_:)` at the same time. This is desirable if you're unlocking functionality that is already inside the app.
 
 * In cases when you need to make a request to your own server in order to unlock the functionality, you can use a **non-atomic** purchase instead.
 
@@ -328,10 +330,10 @@ The `verifySubscription` method can be used together with the `purchaseProduct` 
 let productId = "your-product-id"
 SwiftyStoreKit.purchaseProduct(productId, atomically: true) { result in
     
-    if case .success(let product) = result {
+    if case .success(let purchase) = result {
         // Deliver content from server, then:
-        if product.needsFinishTransaction {
-            SwiftyStoreKit.finishTransaction(product.transaction)
+        if purchase.needsFinishTransaction {
+            SwiftyStoreKit.finishTransaction(purchase.transaction)
         }
         
         let appleValidator = AppleReceiptValidator(service: .production)
@@ -356,7 +358,6 @@ SwiftyStoreKit.purchaseProduct(productId, atomically: true) { result in
                 // receipt verification error
             }
         }
-        
     } else {
         // purchase error
     }
@@ -438,7 +439,7 @@ In order to make a purchase, two operations are needed:
 
 - Submit the payment and listen for updated transactions on the `SKPaymentQueue`.
 
-The framework takes care of caching SKProducts so that future requests for the same ```SKProduct``` don't need to perform a new ```SKProductRequest```.
+The framework takes care of caching SKProducts so that future requests for the same `SKProduct` don't need to perform a new `SKProductRequest`.
 
 ### Payment queue
 
@@ -461,7 +462,7 @@ The order in which transaction updates are processed is:
 2. restore purchases (transactionState: `.restored`, or `restoreCompletedTransactionsFailedWithError`, or `paymentQueueRestoreCompletedTransactionsFinished`)
 3. complete transactions (transactionState: `.purchased`, `.failed`, `.restored`, `.deferred`)
 
-Any transactions where state == `.purchasing` are ignored.
+Any transactions where state is `.purchasing` are ignored.
 
 See [this pull request](https://github.com/bizz84/SwiftyStoreKit/pull/131) for full details about how the payment flows have been implemented.
 

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -39,17 +39,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func completeIAPTransactions() {
 
-        SwiftyStoreKit.completeTransactions(atomically: true) { products in
+        SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 
-            for product in products {
+            for purchase in purchases {
                 // swiftlint:disable:next for_where
-                if product.transaction.transactionState == .purchased || product.transaction.transactionState == .restored {
+                if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
 
-                    if product.needsFinishTransaction {
+                    if purchase.needsFinishTransaction {
                         // Deliver content from server, then:
-                        SwiftyStoreKit.finishTransaction(product.transaction)
+                        SwiftyStoreKit.finishTransaction(purchase.transaction)
                     }
-                    print("purchased: \(product.productId)")
+                    print("purchased: \(purchase.productId)")
                 }
             }
         }

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -79,10 +79,10 @@ class ViewController: UIViewController {
         SwiftyStoreKit.purchaseProduct(appBundleId + "." + purchase.rawValue, atomically: true) { result in
             NetworkActivityIndicatorManager.networkOperationFinished()
 
-            if case .success(let product) = result {
+            if case .success(let purchase) = result {
                 // Deliver content from server, then:
-                if product.needsFinishTransaction {
-                    SwiftyStoreKit.finishTransaction(product.transaction)
+                if purchase.needsFinishTransaction {
+                    SwiftyStoreKit.finishTransaction(purchase.transaction)
                 }
             }
             if let alert = self.alertForPurchaseResult(result) {
@@ -97,9 +97,9 @@ class ViewController: UIViewController {
         SwiftyStoreKit.restorePurchases(atomically: true) { results in
             NetworkActivityIndicatorManager.networkOperationFinished()
 
-            for product in results.restoredProducts where product.needsFinishTransaction {
+            for purchase in results.restoredPurchases where purchase.needsFinishTransaction {
                 // Deliver content from server, then:
-                SwiftyStoreKit.finishTransaction(product.transaction)
+                SwiftyStoreKit.finishTransaction(purchase.transaction)
             }
             self.showAlert(self.alertForRestorePurchases(results))
         }
@@ -216,8 +216,8 @@ extension ViewController {
     // swiftlint:disable cyclomatic_complexity
     func alertForPurchaseResult(_ result: PurchaseResult) -> UIAlertController? {
         switch result {
-        case .success(let product):
-            print("Purchase Success: \(product.productId)")
+        case .success(let purchase):
+            print("Purchase Success: \(purchase.productId)")
             return alertWithTitle("Thank You", message: "Purchase completed")
         case .error(let error):
             print("Purchase Failed: \(error)")
@@ -238,18 +238,18 @@ extension ViewController {
             case .cloudServiceNetworkConnectionFailed: // the device could not connect to the nework
                 return alertWithTitle("Purchase failed", message: "Could not connect to the network")
             case .cloudServiceRevoked: // user has revoked permission to use this cloud service
-                return alertWithTitle("Purchase failed", message: "Could service was revoked")
+                return alertWithTitle("Purchase failed", message: "Cloud service was revoked")
             }
         }
     }
 
     func alertForRestorePurchases(_ results: RestoreResults) -> UIAlertController {
 
-        if results.restoreFailedProducts.count > 0 {
-            print("Restore Failed: \(results.restoreFailedProducts)")
+        if results.restoreFailedPurchases.count > 0 {
+            print("Restore Failed: \(results.restoreFailedPurchases)")
             return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
-        } else if results.restoredProducts.count > 0 {
-            print("Restore Success: \(results.restoredProducts)")
+        } else if results.restoredPurchases.count > 0 {
+            print("Restore Success: \(results.restoredPurchases)")
             return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
         } else {
             print("Nothing to Restore")

--- a/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
@@ -35,17 +35,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func completeIAPTransactions() {
 
-        SwiftyStoreKit.completeTransactions(atomically: true) { products in
+        SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 
-            for product in products {
+            for purchase in purchases {
                 // swiftlint:disable:next for_where
-                if product.transaction.transactionState == .purchased || product.transaction.transactionState == .restored {
+                if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
 
-                    if product.needsFinishTransaction {
+                    if purchase.needsFinishTransaction {
                         // Deliver content from server, then:
-                        SwiftyStoreKit.finishTransaction(product.transaction)
+                        SwiftyStoreKit.finishTransaction(purchase.transaction)
                     }
-                    print("purchased: \(product.productId)")
+                    print("purchased: \(purchase.productId)")
                 }
             }
         }

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -77,10 +77,10 @@ class ViewController: NSViewController {
 
         SwiftyStoreKit.purchaseProduct(appBundleId + "." + purchase.rawValue, atomically: true) { result in
 
-            if case .success(let product) = result {
+            if case .success(let purchase) = result {
                 // Deliver content from server, then:
-                if product.needsFinishTransaction {
-                    SwiftyStoreKit.finishTransaction(product.transaction)
+                if purchase.needsFinishTransaction {
+                    SwiftyStoreKit.finishTransaction(purchase.transaction)
                 }
             }
 
@@ -94,7 +94,7 @@ class ViewController: NSViewController {
 
         SwiftyStoreKit.restorePurchases(atomically: true) { results in
 
-            for product in results.restoredProducts where product.needsFinishTransaction {
+            for purchase in results.restoredPurchases where purchase.needsFinishTransaction {
                 // Deliver content from server, then:
                 SwiftyStoreKit.finishTransaction(product.transaction)
             }
@@ -206,8 +206,8 @@ extension ViewController {
 
     func alertForPurchaseResult(_ result: PurchaseResult) -> NSAlert? {
         switch result {
-        case .success(let product):
-            print("Purchase Success: \(product.productId)")
+        case .success(let purchase):
+            print("Purchase Success: \(purchase.productId)")
             return alertWithTitle("Thank You", message: "Purchase completed")
         case .error(let error):
             print("Purchase Failed: \(error)")
@@ -227,11 +227,11 @@ extension ViewController {
 
     func alertForRestorePurchases(_ results: RestoreResults) -> NSAlert {
 
-        if results.restoreFailedProducts.count > 0 {
-            print("Restore Failed: \(results.restoreFailedProducts)")
+        if results.restoreFailedPurchases.count > 0 {
+            print("Restore Failed: \(results.restoreFailedPurchases)")
             return alertWithTitle("Restore failed", message: "Unknown error. Please contact support")
-        } else if results.restoredProducts.count > 0 {
-            print("Restore Success: \(results.restoredProducts)")
+        } else if results.restoredPurchases.count > 0 {
+            print("Restore Success: \(results.restoredPurchases)")
             return alertWithTitle("Purchases Restored", message: "All purchases have been restored")
         } else {
             print("Nothing to Restore")

--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -27,9 +27,9 @@ import StoreKit
 
 struct CompleteTransactions {
     let atomically: Bool
-    let callback: ([Product]) -> Void
+    let callback: ([Purchase]) -> Void
 
-    init(atomically: Bool, callback: @escaping ([Product]) -> Void) {
+    init(atomically: Bool, callback: @escaping ([Purchase]) -> Void) {
         self.atomically = atomically
         self.callback = callback
     }
@@ -47,7 +47,7 @@ class CompleteTransactionsController: TransactionController {
         }
 
         var unhandledTransactions: [SKPaymentTransaction] = []
-        var products: [Product] = []
+        var purchases: [Purchase] = []
 
         for transaction in transactions {
 
@@ -55,9 +55,9 @@ class CompleteTransactionsController: TransactionController {
 
             if transactionState != .purchasing {
 
-                let product = Product(productId: transaction.payment.productIdentifier, transaction: transaction, needsFinishTransaction: !completeTransactions.atomically)
+                let purchase = Purchase(productId: transaction.payment.productIdentifier, quantity: transaction.payment.quantity, transaction: transaction, needsFinishTransaction: !completeTransactions.atomically)
 
-                products.append(product)
+                purchases.append(purchase)
 
                 print("Finishing transaction for payment \"\(transaction.payment.productIdentifier)\" with state: \(transactionState.debugDescription)")
 
@@ -68,8 +68,8 @@ class CompleteTransactionsController: TransactionController {
                 unhandledTransactions.append(transaction)
             }
         }
-        if products.count > 0 {
-            completeTransactions.callback(products)
+        if purchases.count > 0 {
+            completeTransactions.callback(purchases)
         }
 
         return unhandledTransactions

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -36,8 +36,8 @@ protocol TransactionController {
 }
 
 public enum TransactionResult {
-    case purchased(product: Product)
-    case restored(product: Product)
+    case purchased(purchase: Purchase)
+    case restored(purchase: Purchase)
     case failed(error: SKError)
 }
 
@@ -108,6 +108,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
 
         let skPayment = SKMutablePayment(product: payment.product)
         skPayment.applicationUsername = payment.applicationUsername
+        skPayment.quantity = payment.quantity
         paymentQueue.add(skPayment)
 
         paymentsController.append(payment)

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -27,6 +27,7 @@ import StoreKit
 
 struct Payment: Hashable {
     let product: SKProduct
+    let quantity: Int
     let atomically: Bool
     let applicationUsername: String
     let callback: (TransactionResult) -> Void
@@ -72,9 +73,9 @@ class PaymentsController: TransactionController {
 
         if transactionState == .purchased {
 
-            let product = Product(productId: transactionProductIdentifier, transaction: transaction, needsFinishTransaction: !payment.atomically)
+            let purchase = Purchase(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, needsFinishTransaction: !payment.atomically)
 
-            payment.callback(.purchased(product: product))
+            payment.callback(.purchased(purchase: purchase))
 
             if payment.atomically {
                 paymentQueue.finishTransaction(transaction)

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -27,8 +27,9 @@ import StoreKit
 // MARK: Purchases
 
 // Purchased or restored product
-public struct Product {
+public struct Purchase {
     public let productId: String
+    public let quantity: Int
     public let transaction: PaymentTransaction
     public let needsFinishTransaction: Bool
 }
@@ -56,14 +57,14 @@ public struct RetrieveResults {
 
 // Purchase result
 public enum PurchaseResult {
-    case success(product: Product)
+    case success(purchase: Purchase)
     case error(error: SKError)
 }
 
 // Restore purchase results
 public struct RestoreResults {
-    public let restoredProducts: [Product]
-    public let restoreFailedProducts: [(SKError, String?)]
+    public let restoredPurchases: [Purchase]
+    public let restoreFailedPurchases: [(SKError, String?)]
 }
 
 // MARK: Receipt verification

--- a/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
+++ b/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
@@ -36,11 +36,11 @@ class CompleteTransactionsControllerTests: XCTestCase {
         let transaction = TestPaymentTransaction(payment: SKPayment(product: testProduct), transactionState: .restored)
 
         var callbackCalled = false
-        let completeTransactions = CompleteTransactions(atomically: true) { products in
+        let completeTransactions = CompleteTransactions(atomically: true) { purchases in
             callbackCalled = true
-            XCTAssertEqual(products.count, 1)
-            let product = products.first!
-            XCTAssertEqual(product.productId, productIdentifier)
+            XCTAssertEqual(purchases.count, 1)
+            let purchase = purchases.first!
+            XCTAssertEqual(purchase.productId, productIdentifier)
         }
 
         let completeTransactionsController = makeCompleteTransactionsController(completeTransactions: completeTransactions)
@@ -67,12 +67,12 @@ class CompleteTransactionsControllerTests: XCTestCase {
         ]
 
         var callbackCalled = false
-        let completeTransactions = CompleteTransactions(atomically: true) { products in
+        let completeTransactions = CompleteTransactions(atomically: true) { purchases in
             callbackCalled = true
-            XCTAssertEqual(products.count, 4)
+            XCTAssertEqual(purchases.count, 4)
 
             for i in 0..<4 {
-                XCTAssertEqual(products[i].productId, transactions[i].payment.productIdentifier)
+                XCTAssertEqual(purchases[i].productId, transactions[i].payment.productIdentifier)
             }
         }
 

--- a/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
@@ -29,8 +29,9 @@ import StoreKit
 @testable import SwiftyStoreKit
 
 extension Payment {
-    init(product: SKProduct, atomically: Bool, applicationUsername: String, callback: @escaping (TransactionResult) -> Void) {
+    init(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String, callback: @escaping (TransactionResult) -> Void) {
         self.product = product
+        self.quantity = quantity
         self.atomically = atomically
         self.applicationUsername = applicationUsername
         self.callback = callback
@@ -110,19 +111,19 @@ class PaymentQueueControllerTests: XCTestCase {
             restorePurchasesCallbackCalled = true
             XCTAssertEqual(results.count, 1)
             let first = results.first!
-            if case .restored(let restoredProduct) = first {
-                XCTAssertEqual(restoredProduct.productId, restoredProductIdentifier)
+            if case .restored(let restoredPayment) = first {
+                XCTAssertEqual(restoredPayment.productId, restoredProductIdentifier)
             } else {
                 XCTFail("expected restored callback with product")
             }
         }
 
         var completeTransactionsCallbackCalled = false
-        let completeTransactions = CompleteTransactions(atomically: true) { products in
+        let completeTransactions = CompleteTransactions(atomically: true) { purchases in
             completeTransactionsCallbackCalled = true
-            XCTAssertEqual(products.count, 2)
-            XCTAssertEqual(products[0].productId, failedProductIdentifier)
-            XCTAssertEqual(products[1].productId, deferredProductIdentifier)
+            XCTAssertEqual(purchases.count, 2)
+            XCTAssertEqual(purchases[0].productId, failedProductIdentifier)
+            XCTAssertEqual(purchases[1].productId, deferredProductIdentifier)
         }
 
         // run
@@ -165,20 +166,20 @@ class PaymentQueueControllerTests: XCTestCase {
         var paymentCallbackCalled = false
         let testPayment = makeTestPayment(productIdentifier: purchasedProductIdentifier) { result in
             paymentCallbackCalled = true
-            if case .purchased(let product) = result {
-                XCTAssertEqual(product.productId, purchasedProductIdentifier)
+            if case .purchased(let payment) = result {
+                XCTAssertEqual(payment.productId, purchasedProductIdentifier)
             } else {
                 XCTFail("expected purchased callback with product id")
             }
         }
 
         var completeTransactionsCallbackCalled = false
-        let completeTransactions = CompleteTransactions(atomically: true) { products in
+        let completeTransactions = CompleteTransactions(atomically: true) { payments in
             completeTransactionsCallbackCalled = true
-            XCTAssertEqual(products.count, 3)
-            XCTAssertEqual(products[0].productId, failedProductIdentifier)
-            XCTAssertEqual(products[1].productId, restoredProductIdentifier)
-            XCTAssertEqual(products[2].productId, deferredProductIdentifier)
+            XCTAssertEqual(payments.count, 3)
+            XCTAssertEqual(payments[0].productId, failedProductIdentifier)
+            XCTAssertEqual(payments[1].productId, restoredProductIdentifier)
+            XCTAssertEqual(payments[2].productId, deferredProductIdentifier)
         }
 
         // run
@@ -220,20 +221,20 @@ class PaymentQueueControllerTests: XCTestCase {
             restorePurchasesCallbackCalled = true
             XCTAssertEqual(results.count, 1)
             let first = results.first!
-            if case .restored(let restoredProduct) = first {
-                XCTAssertEqual(restoredProduct.productId, restoredProductIdentifier)
+            if case .restored(let restoredPayment) = first {
+                XCTAssertEqual(restoredPayment.productId, restoredProductIdentifier)
             } else {
                 XCTFail("expected restored callback with product")
             }
         }
 
         var completeTransactionsCallbackCalled = false
-        let completeTransactions = CompleteTransactions(atomically: true) { products in
+        let completeTransactions = CompleteTransactions(atomically: true) { payments in
             completeTransactionsCallbackCalled = true
-            XCTAssertEqual(products.count, 3)
-            XCTAssertEqual(products[0].productId, purchasedProductIdentifier)
-            XCTAssertEqual(products[1].productId, failedProductIdentifier)
-            XCTAssertEqual(products[2].productId, deferredProductIdentifier)
+            XCTAssertEqual(payments.count, 3)
+            XCTAssertEqual(payments[0].productId, purchasedProductIdentifier)
+            XCTAssertEqual(payments[1].productId, failedProductIdentifier)
+            XCTAssertEqual(payments[2].productId, deferredProductIdentifier)
         }
 
         // run
@@ -256,9 +257,9 @@ class PaymentQueueControllerTests: XCTestCase {
         return TestPaymentTransaction(payment: SKPayment(product: testProduct), transactionState: transactionState)
     }
 
-    func makeTestPayment(productIdentifier: String, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
+    func makeTestPayment(productIdentifier: String, quantity: Int = 1, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
         let testProduct = TestProduct(productIdentifier: productIdentifier)
-        return Payment(product: testProduct, atomically: atomically, applicationUsername: "", callback: callback)
+        return Payment(product: testProduct, quantity: quantity, atomically: atomically, applicationUsername: "", callback: callback)
     }
 }

--- a/SwiftyStoreKitTests/PaymentsControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentsControllerTests.swift
@@ -46,8 +46,8 @@ class PaymentsControllerTests: XCTestCase {
         let payment = makeTestPayment(product: testProduct) { result in
 
             callbackCalled = true
-            if case .purchased(let product) = result {
-                XCTAssertEqual(product.productId, productIdentifier)
+            if case .purchased(let payment) = result {
+                XCTAssertEqual(payment.productId, productIdentifier)
             } else {
                 XCTFail("expected purchased callback with product id")
             }
@@ -112,8 +112,8 @@ class PaymentsControllerTests: XCTestCase {
         let payment1 = makeTestPayment(product: testProduct1) { result in
 
             callback1Called = true
-            if case .purchased(let product) = result {
-                XCTAssertEqual(product.productId, productIdentifier)
+            if case .purchased(let payment) = result {
+                XCTAssertEqual(payment.productId, productIdentifier)
             } else {
                 XCTFail("expected purchased callback with product id")
             }
@@ -160,8 +160,8 @@ class PaymentsControllerTests: XCTestCase {
         let payment1 = makeTestPayment(product: testProduct1) { result in
 
             callback1Called = true
-            if case .purchased(let product) = result {
-                XCTAssertEqual(product.productId, productIdentifier)
+            if case .purchased(let payment) = result {
+                XCTAssertEqual(payment.productId, productIdentifier)
             } else {
                 XCTFail("expected purchased callback with product id")
             }
@@ -190,6 +190,8 @@ class PaymentsControllerTests: XCTestCase {
 
         XCTAssertEqual(spy.finishTransactionCalledCount, 1)
     }
+    
+    // TODO: Test quantity > 1
 
     func makePaymentsController(appendPayments payments: [Payment]) -> PaymentsController {
 
@@ -200,15 +202,15 @@ class PaymentsControllerTests: XCTestCase {
         return paymentsController
     }
 
-    func makeTestPayment(product: SKProduct, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
+    func makeTestPayment(product: SKProduct, quantity: Int = 1, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
-        return Payment(product: product, atomically: atomically, applicationUsername: "", callback: callback)
+        return Payment(product: product, quantity: quantity, atomically: atomically, applicationUsername: "", callback: callback)
     }
 
-    func makeTestPayment(productIdentifier: String, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
+    func makeTestPayment(productIdentifier: String, quantity: Int = 1, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
         let product = TestProduct(productIdentifier: productIdentifier)
-        return makeTestPayment(product: product, atomically: atomically, callback: callback)
+        return makeTestPayment(product: product, quantity: quantity, atomically: atomically, callback: callback)
 
     }
 }

--- a/SwiftyStoreKitTests/RestorePurchasesControllerTests.swift
+++ b/SwiftyStoreKitTests/RestorePurchasesControllerTests.swift
@@ -40,8 +40,8 @@ class RestorePurchasesControllerTests: XCTestCase {
             callbackCalled = true
             XCTAssertEqual(results.count, 1)
             let restored = results.first!
-            if case .restored(let restoredProduct) = restored {
-                XCTAssertEqual(restoredProduct.productId, productIdentifier)
+            if case .restored(let restoredPurchase) = restored {
+                XCTAssertEqual(restoredPurchase.productId, productIdentifier)
             } else {
                 XCTFail("expected restored callback with product")
             }
@@ -86,14 +86,14 @@ class RestorePurchasesControllerTests: XCTestCase {
             callbackCalled = true
             XCTAssertEqual(results.count, 2)
             let first = results.first!
-            if case .restored(let restoredProduct) = first {
-                XCTAssertEqual(restoredProduct.productId, productIdentifier1)
+            if case .restored(let restoredPurchase) = first {
+                XCTAssertEqual(restoredPurchase.productId, productIdentifier1)
             } else {
                 XCTFail("expected restored callback with product")
             }
             let last = results.last!
-            if case .restored(let restoredProduct) = last {
-                XCTAssertEqual(restoredProduct.productId, productIdentifier2)
+            if case .restored(let restoredPurchase) = last {
+                XCTAssertEqual(restoredPurchase.productId, productIdentifier2)
             } else {
                 XCTFail("expected restored callback with product")
             }


### PR DESCRIPTION
Fix for #200.

### This is an API breaking change

`Product` renamed to `Purchase` (+ added `quantity`):

```swift
public struct Purchase {
    public let productId: String
    public let quantity: Int
    public let transaction: PaymentTransaction
    public let needsFinishTransaction: Bool
}
```

### PurchaseResult
From this:
```swift
public enum PurchaseResult {
    case success(product: Product)
    case error(error: SKError)
}
```

to this:
```swift
public enum PurchaseResult {
    case success(purchase: Purchase)
    case error(error: SKError)
}
```

### RestoreResults
From this:
```swift
public struct RestoreResults {
    public let restoredProducts: [Product]
    public let restoreFailedProducts: [(SKError, String?)]
}
```

to this:
```swift
public struct RestoreResults {
    public let restoredPurchases: [Purchase]
    public let restoreFailedPurchases: [(SKError, String?)]
}
```
