### PR TITLE
Add originalTransaction from SKPaymentTransaction.original to Payment type

### DIFF
--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -55,7 +55,7 @@ class CompleteTransactionsController: TransactionController {
 
             if transactionState != .purchasing {
 
-                let purchase = Purchase(productId: transaction.payment.productIdentifier, quantity: transaction.payment.quantity, transaction: transaction, needsFinishTransaction: !completeTransactions.atomically)
+                let purchase = Purchase(productId: transaction.payment.productIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !completeTransactions.atomically)
 
                 purchases.append(purchase)
 

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -73,7 +73,7 @@ class PaymentsController: TransactionController {
 
         if transactionState == .purchased {
 
-            let purchase = Purchase(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, needsFinishTransaction: !payment.atomically)
+            let purchase = Purchase(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !payment.atomically)
 
             payment.callback(.purchased(purchase: purchase))
 

--- a/SwiftyStoreKit/RestorePurchasesController.swift
+++ b/SwiftyStoreKit/RestorePurchasesController.swift
@@ -51,7 +51,7 @@ class RestorePurchasesController: TransactionController {
 
             let transactionProductIdentifier = transaction.payment.productIdentifier
             
-            let purchase = Purchase(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, needsFinishTransaction: !atomically)
+            let purchase = Purchase(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !atomically)
             if atomically {
                 paymentQueue.finishTransaction(transaction)
             }

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -31,6 +31,7 @@ public struct Purchase {
     public let productId: String
     public let quantity: Int
     public let transaction: PaymentTransaction
+    public let originalTransaction: PaymentTransaction?
     public let needsFinishTransaction: Bool
 }
 


### PR DESCRIPTION
This is a fix for #193.

As a solution I have decided to make both `transaction` and `originalTransaction` available inside `Payment`. This is so that I don't have to make an arbitrary decision about which one the user wants to use.
