### PR TITLE
Make webOrderLineItemId optional in ReceiptItem 

### DIFF
--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -45,8 +45,7 @@ extension ReceiptItem {
             let transactionId = receiptInfo["transaction_id"] as? String,
             let originalTransactionId = receiptInfo["original_transaction_id"] as? String,
             let purchaseDate = ReceiptItem.parseDate(from: receiptInfo, key: "purchase_date_ms"),
-            let originalPurchaseDate = ReceiptItem.parseDate(from: receiptInfo, key: "original_purchase_date_ms"),
-            let webOrderLineItemId = receiptInfo["web_order_line_item_id"] as? String
+            let originalPurchaseDate = ReceiptItem.parseDate(from: receiptInfo, key: "original_purchase_date_ms")
             else {
                 print("could not parse receipt item: \(receiptInfo). Skipping...")
                 return nil
@@ -57,7 +56,7 @@ extension ReceiptItem {
         self.originalTransactionId = originalTransactionId
         self.purchaseDate = purchaseDate
         self.originalPurchaseDate = originalPurchaseDate
-        self.webOrderLineItemId = webOrderLineItemId
+        self.webOrderLineItemId = receiptInfo["web_order_line_item_id"] as? String
         self.subscriptionExpirationDate = ReceiptItem.parseDate(from: receiptInfo, key: "expires_date_ms")
         self.cancellationDate = ReceiptItem.parseDate(from: receiptInfo, key: "cancellation_date_ms")
         if let isTrialPeriod = receiptInfo["is_trial_period"] as? String {

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -125,7 +125,7 @@ public struct ReceiptItem {
     // For a transaction that restores a previous transaction, the date of the original transaction. This value corresponds to the original transaction’s transactionDate property. In an auto-renewable subscription receipt, this indicates the beginning of the subscription period, even if the subscription has been renewed.
     public let originalPurchaseDate: Date
     // The primary key for identifying subscription purchases.
-    public let webOrderLineItemId: String
+    public let webOrderLineItemId: String?
     // The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT. This key is only present for auto-renewable subscription receipts.
     public let subscriptionExpirationDate: Date?
     // For a transaction that was canceled by Apple customer support, the time and date of the cancellation. Treat a canceled receipt the same as if no purchase had ever been made.

--- a/SwiftyStoreKitTests/InAppReceiptTests.swift
+++ b/SwiftyStoreKitTests/InAppReceiptTests.swift
@@ -55,8 +55,7 @@ extension ReceiptItem: Equatable {
             "original_purchase_date_ms": originalPurchaseDate.timeIntervalSince1970.millisecondsNSString,
             "is_trial_period": (isTrialPeriod ? "1" : "0") as NSString,
             "transaction_id": transactionId as NSString,
-            "original_transaction_id": originalTransactionId as NSString,
-            "web_order_line_item_id": webOrderLineItemId as NSString
+            "original_transaction_id": originalTransactionId as NSString
         ]
         if let subscriptionExpirationDate = subscriptionExpirationDate {
             result["expires_date_ms"] = subscriptionExpirationDate.timeIntervalSince1970.millisecondsNSString


### PR DESCRIPTION
This is to prevent receipt verification failure (see #208).

