### PR TITLE
Feature/unhandled transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next Release
+
+* Add `unhandledTransactions` class variable to provide access to unhandled transactions on the PaymentQueue, add `transactions` variable to `PaymentQueue` protocol
+([#242](https://github.com/bizz84/SwiftyStoreKit/pull/242))
+
 ## 0.10.3 Add `forceRefresh` option to `verifyReceipt`
 
 * Add `forceRefresh` option to `verifyReceipt` ([#224](https://github.com/bizz84/SwiftyStoreKit/pull/224), fix for [#223](https://github.com/bizz84/SwiftyStoreKit/issues/223))

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If there are no pending transactions, the completion block will **not** be calle
 
 Note that `completeTransactions()` **should only be called once** in your code, in `application(:didFinishLaunchingWithOptions:)`.
 
+In addition, at any point in time, array of unfinished transactions on the payment queue can be accessed via `SwiftyStoreKit.unhandledTransactions`. Only valid while the queue has observers.
+
 ## Purchases
 
 ### Retrieve products info

--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -39,25 +39,6 @@ class CompleteTransactionsController: TransactionController {
 
     var completeTransactions: CompleteTransactions?
 
-	var unhandledTransactions: [Purchase] {
-		guard let completeTransactions = completeTransactions else {
-			return []
-		}
-		let purchases = SKPaymentQueue.default().transactions.flatMap { transaction -> Purchase? in
-			guard transaction.transactionState != .purchasing else {
-				return nil
-			}
-			return Purchase(
-				productId: transaction.payment.productIdentifier,
-				quantity: transaction.payment.quantity,
-				transaction: transaction, originalTransaction: transaction.original,
-				needsFinishTransaction:
-				!completeTransactions.atomically
-			)
-		}
-		return purchases
-	}
-
     func processTransactions(_ transactions: [SKPaymentTransaction], on paymentQueue: PaymentQueue) -> [SKPaymentTransaction] {
 
         guard let completeTransactions = completeTransactions else {

--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -39,6 +39,25 @@ class CompleteTransactionsController: TransactionController {
 
     var completeTransactions: CompleteTransactions?
 
+	var unhandledTransactions: [Purchase] {
+		guard let completeTransactions = completeTransactions else {
+			return []
+		}
+		let purchases = SKPaymentQueue.default().transactions.flatMap { transaction -> Purchase? in
+			guard transaction.transactionState != .purchasing else {
+				return nil
+			}
+			return Purchase(
+				productId: transaction.payment.productIdentifier,
+				quantity: transaction.payment.quantity,
+				transaction: transaction, originalTransaction: transaction.original,
+				needsFinishTransaction:
+				!completeTransactions.atomically
+			)
+		}
+		return purchases
+	}
+
     func processTransactions(_ transactions: [SKPaymentTransaction], on paymentQueue: PaymentQueue) -> [SKPaymentTransaction] {
 
         guard let completeTransactions = completeTransactions else {

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -91,6 +91,25 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         paymentQueue.remove(self)
     }
 
+	var unhandledTransactions: [Purchase] {
+		guard let completeTransactions = completeTransactionsController.completeTransactions else {
+			return []
+		}
+		let purchases = SKPaymentQueue.default().transactions.flatMap { transaction -> Purchase? in
+			guard transaction.transactionState != .purchasing else {
+				return nil
+			}
+			return Purchase(
+				productId: transaction.payment.productIdentifier,
+				quantity: transaction.payment.quantity,
+				transaction: transaction, originalTransaction: transaction.original,
+				needsFinishTransaction:
+				!completeTransactions.atomically
+			)
+		}
+		return purchases
+	}
+
     init(paymentQueue: PaymentQueue = SKPaymentQueue.default(),
          paymentsController: PaymentsController = PaymentsController(),
          restorePurchasesController: RestorePurchasesController = RestorePurchasesController(),

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -43,7 +43,10 @@ public enum TransactionResult {
 
 public protocol PaymentQueue: class {
 
+	var transactions: [SKPaymentTransaction] { get }
+
     func add(_ observer: SKPaymentTransactionObserver)
+
     func remove(_ observer: SKPaymentTransactionObserver)
 
     func add(_ payment: SKPayment)
@@ -93,9 +96,10 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
 
 	var unhandledTransactions: [Purchase] {
 		guard let completeTransactions = completeTransactionsController.completeTransactions else {
+			print("SwiftyStoreKit.completeTransactions() should be called once when the app launches. Returning no results")
 			return []
 		}
-		let purchases = SKPaymentQueue.default().transactions.flatMap { transaction -> Purchase? in
+		let purchases = paymentQueue.transactions.flatMap { transaction -> Purchase? in
 			guard transaction.transactionState != .purchasing else {
 				return nil
 			}

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -102,9 +102,9 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
 			return Purchase(
 				productId: transaction.payment.productIdentifier,
 				quantity: transaction.payment.quantity,
-				transaction: transaction, originalTransaction: transaction.original,
-				needsFinishTransaction:
-				!completeTransactions.atomically
+				transaction: transaction,
+				originalTransaction: transaction.original,
+				needsFinishTransaction: !completeTransactions.atomically
 			)
 		}
 		return purchases

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -28,7 +28,7 @@ public class SwiftyStoreKit {
 
     private let productsInfoController: ProductsInfoController
 
-    private let paymentQueueController: PaymentQueueController
+    fileprivate let paymentQueueController: PaymentQueueController
 
     fileprivate let receiptVerificator: InAppReceiptVerificator
 
@@ -133,6 +133,10 @@ extension SwiftyStoreKit {
     fileprivate static let sharedInstance = SwiftyStoreKit()
 
     // MARK: Public methods - Purchases
+
+	public class var unhandledTransactions: [Purchase] {
+		return sharedInstance.paymentQueueController.unhandledTransactions
+	}
     
     public class var canMakePayments: Bool {
         return SKPaymentQueue.canMakePayments()

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -135,8 +135,8 @@ extension SwiftyStoreKit {
     // MARK: Public methods - Purchases
 
 	/** 
-	 *	Retrieve unhandled transactions from default payment queue
-	 *	- Returns: Array of unhandled Purchases, empty if there is no unhandled transaction
+	 *	Retrieve unhandled transactions from payment queue
+	 *	- Returns: Array of unhandled Purchases, empty if there are no unhandled transaction
 	 */
 	public class var unhandledTransactions: [Purchase] {
 		return sharedInstance.paymentQueueController.unhandledTransactions

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -134,6 +134,10 @@ extension SwiftyStoreKit {
 
     // MARK: Public methods - Purchases
 
+	/** 
+	 *	Retrieve unhandled transactions from default payment queue
+	 *	- Returns: Array of unhandled Purchases, empty if there is no unhandled transaction
+	 */
 	public class var unhandledTransactions: [Purchase] {
 		return sharedInstance.paymentQueueController.unhandledTransactions
 	}


### PR DESCRIPTION
This PR exposes a new class variable `unhandledTransactions` to API consumer. This gives API consumer the flexibility to have their own way of handling pending transactions instead of being forced to handle it on app launch. (e.g: they can access this data and show custom UI to handle pending transactions)



