### PR TITLE
Unwrap receipt["receipt"]?["in_app"] in two steps to work around cast returning nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Add `fetchReceipt` method. Update `verifyReceipt` to use it ([#278](https://github.com/bizz84/SwiftyStoreKit/pull/278), related issues: [#272](https://github.com/bizz84/SwiftyStoreKit/issues/272), [#223](https://github.com/bizz84/SwiftyStoreKit/issues/223)).
 * Remove `password` from `ReceiptValidator` protocol as this is specific to `AppleReceiptValidator` ([#281](https://github.com/bizz84/SwiftyStoreKit/pull/281/)). **Note**: This is an API breaking change.
+* Unwrap `receipt["receipt"]?["in_app"]` in two steps (addresses casting problems) ([#283](https://github.com/bizz84/SwiftyStoreKit/pull/283), related issue [#256](https://github.com/bizz84/SwiftyStoreKit/issues/256)).
 
 
 ## [0.10.8](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.10.8) Update to swiftlint 0.22.0

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -92,7 +92,7 @@ internal class InAppReceipt {
     ) -> VerifyPurchaseResult {
 
         // Get receipts info for the product
-        let receipts = getInAppReceipt(receipt: receipt)
+        let receipts = getInAppReceipts(receipt: receipt)
         let filteredReceiptsInfo = filterReceiptsInfo(receipts: receipts, withProductId: productId)
         let nonCancelledReceiptsInfo = filteredReceiptsInfo.filter { receipt in receipt["cancellation_date"] == nil }
 
@@ -174,7 +174,7 @@ internal class InAppReceipt {
         case .autoRenewable:
             return (receipt["latest_receipt_info"] as? [ReceiptInfo], nil)
         case .nonRenewing(let duration):
-            return (getInAppReceipt(receipt: receipt), duration)
+            return (getInAppReceipts(receipt: receipt), duration)
         }
     }
 
@@ -187,7 +187,7 @@ internal class InAppReceipt {
         return Date(millisecondsSince1970: requestDateString)
     }
     
-    private class func getInAppReceipt(receipt: ReceiptInfo) -> [ReceiptInfo]? {
+    private class func getInAppReceipts(receipt: ReceiptInfo) -> [ReceiptInfo]? {
         
         let appReceipt = receipt["receipt"] as? ReceiptInfo
         return appReceipt?["in_app"] as? [ReceiptInfo]

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -92,9 +92,8 @@ internal class InAppReceipt {
     ) -> VerifyPurchaseResult {
 
         // Get receipts info for the product
-        let appReceipt = receipt["receipt"] as? [String: AnyObject]
-        let receiptsInfo = appReceipt?["in_app"] as? [ReceiptInfo]
-        let filteredReceiptsInfo = filterReceiptsInfo(receipts: receiptsInfo, withProductId: productId)
+        let receipts = getInAppReceipt(receipt: receipt)
+        let filteredReceiptsInfo = filterReceiptsInfo(receipts: receipts, withProductId: productId)
         let nonCancelledReceiptsInfo = filteredReceiptsInfo.filter { receipt in receipt["cancellation_date"] == nil }
 
         let receiptItems = nonCancelledReceiptsInfo.flatMap { ReceiptItem(receiptInfo: $0) }
@@ -175,8 +174,7 @@ internal class InAppReceipt {
         case .autoRenewable:
             return (receipt["latest_receipt_info"] as? [ReceiptInfo], nil)
         case .nonRenewing(let duration):
-            let appReceipt = receipt["receipt"] as? [String: AnyObject]
-            return (appReceipt?["in_app"] as? [ReceiptInfo], duration)
+            return (getInAppReceipt(receipt: receipt), duration)
         }
     }
 
@@ -187,6 +185,12 @@ internal class InAppReceipt {
             return nil
         }
         return Date(millisecondsSince1970: requestDateString)
+    }
+    
+    private class func getInAppReceipt(receipt: ReceiptInfo) -> [ReceiptInfo]? {
+        
+        let appReceipt = receipt["receipt"] as? ReceiptInfo
+        return appReceipt?["in_app"] as? [ReceiptInfo]
     }
 
     /**

--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -92,9 +92,10 @@ internal class InAppReceipt {
     ) -> VerifyPurchaseResult {
 
         // Get receipts info for the product
-        let receipts = receipt["receipt"]?["in_app"] as? [ReceiptInfo]
-        let receiptsInfo = filterReceiptsInfo(receipts: receipts, withProductId: productId)
-        let nonCancelledReceiptsInfo = receiptsInfo.filter { receipt in receipt["cancellation_date"] == nil }
+        let appReceipt = receipt["receipt"] as? [String: AnyObject]
+        let receiptsInfo = appReceipt?["in_app"] as? [ReceiptInfo]
+        let filteredReceiptsInfo = filterReceiptsInfo(receipts: receiptsInfo, withProductId: productId)
+        let nonCancelledReceiptsInfo = filteredReceiptsInfo.filter { receipt in receipt["cancellation_date"] == nil }
 
         let receiptItems = nonCancelledReceiptsInfo.flatMap { ReceiptItem(receiptInfo: $0) }
         // Verify that at least one receipt has the right product id
@@ -174,7 +175,8 @@ internal class InAppReceipt {
         case .autoRenewable:
             return (receipt["latest_receipt_info"] as? [ReceiptInfo], nil)
         case .nonRenewing(let duration):
-            return (receipt["receipt"]?["in_app"] as? [ReceiptInfo], duration)
+            let appReceipt = receipt["receipt"] as? [String: AnyObject]
+            return (appReceipt?["in_app"] as? [ReceiptInfo], duration)
         }
     }
 


### PR DESCRIPTION
- [x] Cast in two steps
- [x] Cleanup