### PR TITLE
fetchReceipt: replace String with Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ Use this method to get the updated receipt:
 ```swift
 SwiftyStoreKit.fetchReceipt(forceRefresh: true) { result in
     switch result {
-    case .success(let encryptedReceipt):
+    case .success(let receiptData):
+        let encryptedReceipt = receiptData.base64EncodedString(options: [])
         print("Fetch receipt success:\n\(encryptedReceipt)")
     case .error(let error):
         print("Fetch receipt failed: \(error)")

--- a/SwiftyStoreKit/AppleReceiptValidator.swift
+++ b/SwiftyStoreKit/AppleReceiptValidator.swift
@@ -47,12 +47,13 @@ public struct AppleReceiptValidator: ReceiptValidator {
         self.sharedSecret = sharedSecret
 	}
 
-	public func validate(receipt: String, completion: @escaping (VerifyReceiptResult) -> Void) {
+	public func validate(receiptData: Data, completion: @escaping (VerifyReceiptResult) -> Void) {
 
 		let storeURL = URL(string: service.rawValue)! // safe (until no more)
 		let storeRequest = NSMutableURLRequest(url: storeURL)
 		storeRequest.httpMethod = "POST"
 
+        let receipt = receiptData.base64EncodedString(options: [])
 		let requestContents: NSMutableDictionary = [ "receipt-data": receipt ]
 		// password if defined
 		if let password = sharedSecret {
@@ -106,7 +107,7 @@ public struct AppleReceiptValidator: ReceiptValidator {
 				let receiptStatus = ReceiptStatus(rawValue: status) ?? ReceiptStatus.unknown
 				if case .testReceipt = receiptStatus {
                     let sandboxValidator = AppleReceiptValidator(service: .sandbox, sharedSecret: self.sharedSecret)
-					sandboxValidator.validate(receipt: receipt, completion: completion)
+					sandboxValidator.validate(receiptData: receiptData, completion: completion)
 				} else {
 					if receiptStatus.isValid {
 						completion(.success(receipt: receiptInfo))

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -45,7 +45,7 @@ public struct PurchaseDetails {
 
 //Conform to this protocol to provide custom receipt validator
 public protocol ReceiptValidator {
-	func validate(receipt: String, completion: @escaping (VerifyReceiptResult) -> Void)
+	func validate(receiptData: Data, completion: @escaping (VerifyReceiptResult) -> Void)
 }
 
 // Payment transaction
@@ -91,7 +91,7 @@ public enum RefreshReceiptResult {
 
 // Fetch receipt result
 public enum FetchReceiptResult {
-    case success(encryptedReceipt: String)
+    case success(receiptData: Data)
     case error(error: ReceiptError)
 }
 

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -83,12 +83,6 @@ public typealias ShouldAddStorePaymentHandler = (_ payment: SKPayment, _ product
 // Info for receipt returned by server
 public typealias ReceiptInfo = [String: AnyObject]
 
-// Refresh receipt result
-public enum RefreshReceiptResult {
-    case success(receiptData: Data)
-    case error(error: Error)
-}
-
 // Fetch receipt result
 public enum FetchReceiptResult {
     case success(receiptData: Data)

--- a/SwiftyStoreKitTests/InAppReceiptVerificatorTests.swift
+++ b/SwiftyStoreKitTests/InAppReceiptVerificatorTests.swift
@@ -28,7 +28,7 @@ import XCTest
 
 class TestReceiptValidator: ReceiptValidator {
     var validateCalled = false
-    func validate(receipt: String, completion: @escaping (VerifyReceiptResult) -> Void) {
+    func validate(receiptData: Data, completion: @escaping (VerifyReceiptResult) -> Void) {
         validateCalled = true
         completion(.success(receipt: [:]))
     }


### PR DESCRIPTION
The receipt read from `Bundle.main.appStoreReceiptURL` is a `Data` object.

Maybe it makes sense to return it as such and let clients convert it into a string if needed (for example when uploading as payload to a server):

```swift
let receipt = receiptData.base64EncodedString(options: [])
```

Also, local receipt verification may access the bytes from `Data` rather than `String`.
