### PR TITLE
Remove localizedIntroductoryPrice (restore Xcode 8 compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.2](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.2) Remove `SKProduct.localizedIntroductoryPrice`
+
+* Remove `localizedIntroductoryPrice` ([#320](https://github.com/bizz84/SwiftyStoreKit/pull/320/files), see [#319](https://github.com/bizz84/SwiftyStoreKit/issues/319), [#318](https://github.com/bizz84/SwiftyStoreKit/pull/318), [#315](https://github.com/bizz84/SwiftyStoreKit/pull/315))
+
 ## [0.11.1](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.1) Add `PaymentTransaction.transactionDate` and  `SKProduct.localizedIntroductoryPrice`
 
 * Add `transactionDate` to `PaymentTransaction` ([#316](https://github.com/bizz84/SwiftyStoreKit/pull/316), see [#312](https://github.com/bizz84/SwiftyStoreKit/issues/312)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.11.2](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.2) Remove `SKProduct.localizedIntroductoryPrice`
 
-* Remove `localizedIntroductoryPrice` ([#320](https://github.com/bizz84/SwiftyStoreKit/pull/320/files), see [#319](https://github.com/bizz84/SwiftyStoreKit/issues/319), [#318](https://github.com/bizz84/SwiftyStoreKit/pull/318), [#315](https://github.com/bizz84/SwiftyStoreKit/pull/315))
+* Remove `localizedIntroductoryPrice` ([#320](https://github.com/bizz84/SwiftyStoreKit/pull/320), see [#319](https://github.com/bizz84/SwiftyStoreKit/issues/319), [#318](https://github.com/bizz84/SwiftyStoreKit/pull/318), [#315](https://github.com/bizz84/SwiftyStoreKit/pull/315))
 
 ## [0.11.1](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.1) Add `PaymentTransaction.transactionDate` and  `SKProduct.localizedIntroductoryPrice`
 

--- a/SwiftyStoreKit/SKProduct+LocalizedPrice.swift
+++ b/SwiftyStoreKit/SKProduct+LocalizedPrice.swift
@@ -28,21 +28,13 @@ import StoreKit
 public extension SKProduct {
 
     public var localizedPrice: String? {
-        return formattedPrice(price: price, locale: priceLocale)
+        return priceFormatter(locale: priceLocale).string(from: price)
     }
-
-    @available(iOS 11.2, OSX 10.13.2, tvOS 11.2, *)
-    public var localizedIntroductoryPrice: String? {
-        guard let introductoryPrice = introductoryPrice else {
-            return nil
-        }
-        return formattedPrice(price: introductoryPrice.price, locale: introductoryPrice.priceLocale)
-    }
-
-    private func formattedPrice(price: NSDecimalNumber, locale: Locale) -> String? {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.locale = locale
-        numberFormatter.numberStyle = .currency
-        return numberFormatter.string(from: price)
+    
+    private func priceFormatter(locale: Locale) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .currency
+        return formatter
     }
 }


### PR DESCRIPTION
See #319. Reverts changes in #315.