### PR TITLE
completeTransactions should finish failed transactions if atomically: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.3](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.3) `completeTransactions` should finish failed transactions if `atomically: false`
+
+* `completeTransactions` should finish failed transactions if `atomically: false` ([#322](https://github.com/bizz84/SwiftyStoreKit/pull/322), related issues: [#307](https://github.com/bizz84/SwiftyStoreKit/issues/307), [#288](https://github.com/bizz84/SwiftyStoreKit/issues/288))
+
 ## [0.11.2](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.11.2) Remove `SKProduct.localizedIntroductoryPrice`
 
 * Remove `localizedIntroductoryPrice` ([#320](https://github.com/bizz84/SwiftyStoreKit/pull/320), see [#319](https://github.com/bizz84/SwiftyStoreKit/issues/319), [#318](https://github.com/bizz84/SwiftyStoreKit/pull/318), [#315](https://github.com/bizz84/SwiftyStoreKit/pull/315))

--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ SwiftyStoreKit supports this by calling `completeTransactions()` when the app st
 
 ```swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-    SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
-        for purchase in purchases {
-            if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
-                if purchase.needsFinishTransaction {
-                    // Deliver content from server, then:
-                    SwiftyStoreKit.finishTransaction(purchase.transaction)
-                }
-                print("purchased: \(purchase)")
-            }
-        }
-    }
+	// see notes below for the meaning of Atomic / Non-Atomic
+	SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
+	    for purchase in purchases {
+	        switch purchase.transaction.transactionState {
+	        case .purchased, .restored:
+	            if purchase.needsFinishTransaction {
+	                // Deliver content from server, then:
+	                SwiftyStoreKit.finishTransaction(purchase.transaction)
+	            }
+	            // Unlock content
+	        case .failed, .purchasing, .deferred:
+	            break // do nothing
+	        }
+	    }
+	}
     return true
 }
 ```

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -42,13 +42,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 
             for purchase in purchases {
-                if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
-
+                switch purchase.transaction.transactionState {
+                case .purchased, .restored:
                     if purchase.needsFinishTransaction {
                         // Deliver content from server, then:
                         SwiftyStoreKit.finishTransaction(purchase.transaction)
                     }
-                    print("purchased: \(purchase.productId)")
+                    print("\(purchase.transaction.transactionState.debugDescription): \(purchase.productId)")
+                case .failed, .purchasing, .deferred:
+                    break // do nothing
                 }
             }
         }

--- a/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-macOS-Demo/AppDelegate.swift
@@ -38,13 +38,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 
             for purchase in purchases {
-                if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
-
+                switch purchase.transaction.transactionState {
+                case .purchased, .restored:
                     if purchase.needsFinishTransaction {
                         // Deliver content from server, then:
                         SwiftyStoreKit.finishTransaction(purchase.transaction)
                     }
-                    print("purchased: \(purchase.productId)")
+                    print("\(purchase.transaction.transactionState.debugDescription): \(purchase.productId)")
+                case .failed, .purchasing, .deferred:
+                    break // do nothing
                 }
             }
         }

--- a/SwiftyStoreKit/CompleteTransactionsController.swift
+++ b/SwiftyStoreKit/CompleteTransactionsController.swift
@@ -55,13 +55,13 @@ class CompleteTransactionsController: TransactionController {
 
             if transactionState != .purchasing {
 
-                let purchase = Purchase(productId: transaction.payment.productIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !completeTransactions.atomically)
+                let willFinishTransaction = completeTransactions.atomically || transactionState == .failed
+                let purchase = Purchase(productId: transaction.payment.productIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !willFinishTransaction)
 
                 purchases.append(purchase)
 
-                print("Finishing transaction for payment \"\(transaction.payment.productIdentifier)\" with state: \(transactionState.debugDescription)")
-
-                if completeTransactions.atomically {
+                if willFinishTransaction {
+                    print("Finishing transaction for payment \"\(transaction.payment.productIdentifier)\" with state: \(transactionState.debugDescription)")
                     paymentQueue.finishTransaction(transaction)
                 }
             } else {

--- a/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
+++ b/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
@@ -28,7 +28,7 @@ import StoreKit
 
 class CompleteTransactionsControllerTests: XCTestCase {
 
-    func testProcessTransactions_when_oneRestoredTransaction_then_finishesTransaction_callsCallback_noRemainingTransactions() {
+    func testProcessTransactions_when_atomically_oneRestoredTransaction_then_finishesTransaction_callsCallback_noRemainingTransactions() {
 
         let productIdentifier = "com.SwiftyStoreKit.product1"
         let testProduct = TestProduct(productIdentifier: productIdentifier)
@@ -56,7 +56,65 @@ class CompleteTransactionsControllerTests: XCTestCase {
         XCTAssertEqual(spy.finishTransactionCalledCount, 1)
     }
 
-    func testProcessTransactions_when_oneTransactionForEachState_then_finishesTransactions_callsCallback_onePurchasingTransactionRemaining() {
+    func testProcessTransactions_when_atomically_oneFailedTransaction_then_finishesTransaction_callsCallback_noRemainingTransactions_noNeedsFinishTransactions() {
+        
+        let productIdentifier = "com.SwiftyStoreKit.product1"
+        let testProduct = TestProduct(productIdentifier: productIdentifier)
+        
+        let transaction = TestPaymentTransaction(payment: SKPayment(product: testProduct), transactionState: .failed)
+        
+        var callbackCalled = false
+        let completeTransactions = CompleteTransactions(atomically: true) { purchases in
+            callbackCalled = true
+            XCTAssertEqual(purchases.count, 1)
+            let purchase = purchases.first!
+            XCTAssertFalse(purchase.needsFinishTransaction)
+            XCTAssertEqual(purchase.productId, productIdentifier)
+        }
+        
+        let completeTransactionsController = makeCompleteTransactionsController(completeTransactions: completeTransactions)
+        
+        let spy = PaymentQueueSpy()
+        
+        let remainingTransactions = completeTransactionsController.processTransactions([transaction], on: spy)
+        
+        XCTAssertEqual(remainingTransactions.count, 0)
+        
+        XCTAssertTrue(callbackCalled)
+        
+        XCTAssertEqual(spy.finishTransactionCalledCount, 1)
+    }
+
+    func testProcessTransactions_when_notAtomically_oneFailedTransaction_then_finishesTransaction_callsCallback_noRemainingTransactions_noNeedsFinishTransactions() {
+        
+        let productIdentifier = "com.SwiftyStoreKit.product1"
+        let testProduct = TestProduct(productIdentifier: productIdentifier)
+        
+        let transaction = TestPaymentTransaction(payment: SKPayment(product: testProduct), transactionState: .failed)
+        
+        var callbackCalled = false
+        let completeTransactions = CompleteTransactions(atomically: false) { purchases in
+            callbackCalled = true
+            XCTAssertEqual(purchases.count, 1)
+            let purchase = purchases.first!
+            XCTAssertFalse(purchase.needsFinishTransaction)
+            XCTAssertEqual(purchase.productId, productIdentifier)
+        }
+        
+        let completeTransactionsController = makeCompleteTransactionsController(completeTransactions: completeTransactions)
+        
+        let spy = PaymentQueueSpy()
+        
+        let remainingTransactions = completeTransactionsController.processTransactions([transaction], on: spy)
+        
+        XCTAssertEqual(remainingTransactions.count, 0)
+        
+        XCTAssertTrue(callbackCalled)
+        
+        XCTAssertEqual(spy.finishTransactionCalledCount, 1)
+    }
+
+    func testProcessTransactions_when_atomically_oneTransactionForEachState_then_finishesTransactions_callsCallback_onePurchasingTransactionRemaining() {
 
         let transactions = [
             makeTestPaymentTransaction(productIdentifier: "com.SwiftyStoreKit.product1", transactionState: .purchased),
@@ -89,7 +147,7 @@ class CompleteTransactionsControllerTests: XCTestCase {
         XCTAssertEqual(spy.finishTransactionCalledCount, 4)
     }
 
-    func testProcessTransactions_when_zeroTransactions_then_noFinishedTransactions_noCallback_noTransactionsRemaining() {
+    func testProcessTransactions_when_atomically_zeroTransactions_then_noFinishedTransactions_noCallback_noTransactionsRemaining() {
 
         let transactions: [TestPaymentTransaction] = []
 
@@ -108,7 +166,7 @@ class CompleteTransactionsControllerTests: XCTestCase {
         XCTAssertEqual(spy.finishTransactionCalledCount, 0)
     }
 
-    func testProcessTransactions_when_onePurchasingTransaction_then_noFinishedTransactions_noCallback_oneTransactionsRemaining() {
+    func testProcessTransactions_when_atomically_onePurchasingTransaction_then_noFinishedTransactions_noCallback_oneTransactionsRemaining() {
 
         let productIdentifier = "com.SwiftyStoreKit.product1"
         let testProduct = TestProduct(productIdentifier: productIdentifier)
@@ -130,6 +188,7 @@ class CompleteTransactionsControllerTests: XCTestCase {
         XCTAssertEqual(spy.finishTransactionCalledCount, 0)
     }
 
+    
     func makeTestPaymentTransaction(productIdentifier: String, transactionState: SKPaymentTransactionState) -> TestPaymentTransaction {
 
         let testProduct = TestProduct(productIdentifier: productIdentifier)

--- a/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
+++ b/SwiftyStoreKitTests/CompleteTransactionsControllerTests.swift
@@ -187,7 +187,6 @@ class CompleteTransactionsControllerTests: XCTestCase {
 
         XCTAssertEqual(spy.finishTransactionCalledCount, 0)
     }
-
     
     func makeTestPaymentTransaction(productIdentifier: String, transactionState: SKPaymentTransactionState) -> TestPaymentTransaction {
 


### PR DESCRIPTION
## Context

Non-Atomic transactions are useful when the application needs to deliver content from the server before finishing a transaction.

When the application starts, it is best practice to call `SwiftyStoreKit.completeTransactions`. This method makes it possible to clear all transactions that may have completed while the app was not running. 

Crucially, this applies to `.purchased`, `.restored` and **`.failed`** transactions. See Apple Docs for `SKPaymentQueue`: 
```
// Asynchronous.  Remove a finished (i.e. failed or completed) transaction from the queue.  Attempting to finish a purchasing transaction will throw an exception.
@available(iOS 3.0, *)
open func finishTransaction(_ transaction: SKPaymentTransaction)
```

As of SwiftyStoreKit 0.11.2, calling `SwiftyStoreKit.completeTransactions(atomically: false)` does **not** call `finishTransactions` on `.failed` transactions.

This is not in line with `purchaseProduct` and `restorePurchases`, which both call `finishTransactions` on `.failed` transactions, regardless of the `atomically` flag.

### Why this matters (side effects)

When transactions are not finished, they hang out in the payment queue indefinitely, and can cause problems with later purchases.

Consider this example:

* User tries to purchase a product, but the transaction fails after the app is killed.
* User opens the app again, which is configured with `SwiftyStoreKit.completeTransactions(atomically: false)`
* The `.failed` transaction is not finished.
* User tries to purchase the same product again, and the purchase fails immediately. This happens because the old (failed) transaction is still in the queue and SwiftyStoreKit thinks it matches the new purchase as the product ID is the same.
* At this point, the old transaction is finished and the callback for the new purchase is called. The transaction for the new purchase is now in the queue (and may be handled by `completeTransactions` later).

### How to fix this

Modify the implementation of `completeTransactions` to ensure failed transactions are always finished, even if `atomically: false`. 

This ensures that all completed transactions are always caught and finished when the app launches, as long as `SwiftyStoreKit.completeTransactions` is called.

With this fix, it's also essential that `purchase.needsFinishTransaction` is **always** `false` when `completeTransactions` returns a failed transaction, regardless of the value of `atomically`.

For more clarity, the README will be updated to use a `switch` statement in the completion block of `completeTransactions`.

```swift
SwiftyStoreKit.completeTransactions(atomically: false) { purchases in
    for purchase in purchases {
        switch purchase.transaction.transactionState {
        case .purchased, .restored:
            if purchase.needsFinishTransaction {
                // Deliver content from server, then:
                SwiftyStoreKit.finishTransaction(purchase.transaction)
            }
        case .failed, .purchasing, .deferred:
            break // do nothing
        }
    }
}
```

Note that with this fix, apps using the old sample code from the README should now work correctly:

```swift 
SwiftyStoreKit.completeTransactions(atomically: false) { purchases in
    for purchase in purchases {
        if purchase.transaction.transactionState == .purchased || purchase.transaction.transactionState == .restored {
            if purchase.needsFinishTransaction {
                // Deliver content from server, then:
                SwiftyStoreKit.finishTransaction(purchase.transaction)
            }
            print("purchased: \(purchase)")
        }
    }
}
```