### PR TITLE
Assert that completeTransactions() was called when the app launches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.1](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.12.1) Assert that `completeTransactions` was called when the app launches.
+
+* Assert that `completeTransactions()` was called when the app launches ([#337](https://github.com/bizz84/SwiftyStoreKit/pull/337), related issue: [#287](https://github.com/bizz84/SwiftyStoreKit/issues/287))
+
 ## [0.12.0](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.12.0) Add `verifySubscriptions` method for subscription groups 
 
 * Add `verifySubscriptions` method to check all subscriptions in a group at once ([#333](https://github.com/bizz84/SwiftyStoreKit/pull/333), related issue: [#194](https://github.com/bizz84/SwiftyStoreKit/issues/194))

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -103,9 +103,16 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         super.init()
         paymentQueue.add(self)
     }
+    
+    private func assertCompleteTransactionsWasCalled() {
+        
+        let message = "SwiftyStoreKit.completeTransactions() must be called when the app launches."
+        assert(completeTransactionsController.completeTransactions != nil, message)
+    }
 
     func startPayment(_ payment: Payment) {
-
+        assertCompleteTransactionsWasCalled()
+        
         let skPayment = SKMutablePayment(product: payment.product)
         skPayment.applicationUsername = payment.applicationUsername
         skPayment.quantity = payment.quantity
@@ -115,6 +122,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
     }
 
     func restorePurchases(_ restorePurchases: RestorePurchases) {
+        assertCompleteTransactionsWasCalled()
 
         if restorePurchasesController.restorePurchases != nil {
             return

--- a/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
@@ -69,6 +69,8 @@ class PaymentQueueControllerTests: XCTestCase {
 
         let payment = makeTestPayment(productIdentifier: "com.SwiftyStoreKit.product1") { _ in }
 
+        paymentQueueController.completeTransactions(CompleteTransactions(atomically: true) { _ in })
+
         paymentQueueController.startPayment(payment)
 
         XCTAssertEqual(spy.payments.count, 1)
@@ -127,11 +129,11 @@ class PaymentQueueControllerTests: XCTestCase {
         }
 
         // run
+        paymentQueueController.completeTransactions(completeTransactions)
+
         paymentQueueController.startPayment(testPayment)
 
         paymentQueueController.restorePurchases(restorePurchases)
-
-        paymentQueueController.completeTransactions(completeTransactions)
 
         paymentQueueController.paymentQueue(SKPaymentQueue(), updatedTransactions: transactions)
         paymentQueueController.paymentQueueRestoreCompletedTransactionsFinished(SKPaymentQueue())
@@ -183,9 +185,9 @@ class PaymentQueueControllerTests: XCTestCase {
         }
 
         // run
-        paymentQueueController.startPayment(testPayment)
-
         paymentQueueController.completeTransactions(completeTransactions)
+
+        paymentQueueController.startPayment(testPayment)
 
         paymentQueueController.paymentQueue(SKPaymentQueue(), updatedTransactions: transactions)
         paymentQueueController.paymentQueueRestoreCompletedTransactionsFinished(SKPaymentQueue())
@@ -238,9 +240,9 @@ class PaymentQueueControllerTests: XCTestCase {
         }
 
         // run
-        paymentQueueController.restorePurchases(restorePurchases)
-
         paymentQueueController.completeTransactions(completeTransactions)
+
+        paymentQueueController.restorePurchases(restorePurchases)
 
         paymentQueueController.paymentQueue(SKPaymentQueue(), updatedTransactions: transactions)
         paymentQueueController.paymentQueueRestoreCompletedTransactionsFinished(SKPaymentQueue())


### PR DESCRIPTION
- [x] Assert that `completeTransactions()` was called when the app launches.
- [x] Update PaymentQueueControllerTests to enqueue purchase calls in the correct order.

Related issue: #287.

### Discussion

This PR adds a runtime assertion to check that `completeTransactions()` was called when the app launches. The assertion is checked when calling `purchaseProduct()` or `restorePurchases()`, as these calls are most likely to yield undesired results without a prior call to `completeTransactions()`.

A better way of doing this would be to transform the runtime check into a compile-time constraint. 
This could be done by making the `CompleteTransactions` struct a non-optional parameter passed to the initializer of SwiftyStoreKit. Example:

```swift
let swiftyStoreKit = SwiftyStoreKit(CompleteTransactions(atomically: atomically, callback: { purchases in 
   // ...
})
// save swiftyStoreKit and use elsewhere
```
This would require SwiftyStoreKit to **not** be a singleton, which would be a big API-breaking change that affects all clients.

For the time being - I will keep this as a runtime check. Hopefully this is enough to prevent problems down the line in testing.

