### PR TITLE
Add support for downloading content hosted by Apple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.13.0) Add support for downloading content hosted with Apple
+
+* Add support for downloading content hosted with Apple ([#343](https://github.com/bizz84/SwiftyStoreKit/pull/343), related issue: [#128](https://github.com/bizz84/SwiftyStoreKit/issues/128))
+
 ## [0.12.1](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.12.1) Assert that `completeTransactions` was called when the app launches.
 
 * Assert that `completeTransactions()` was called when the app launches ([#337](https://github.com/bizz84/SwiftyStoreKit/pull/337), related issue: [#287](https://github.com/bizz84/SwiftyStoreKit/issues/287))

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -32,20 +32,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
 
-        completeIAPTransactions()
-        
-        SwiftyStoreKit.updatedDownloadsHandler = { downloads in
-            
-            let finishedDownloadsCount = downloads.filter { $0.downloadState == .finished }.count
-            if finishedDownloadsCount == downloads.count {
-                SwiftyStoreKit.finishTransaction(downloads[0].transaction)
-            }
-        }
+        setupIAP()
 
         return true
     }
 
-    func completeIAPTransactions() {
+    func setupIAP() {
 
         SwiftyStoreKit.completeTransactions(atomically: true) { purchases in
 
@@ -63,6 +55,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 case .failed, .purchasing, .deferred:
                     break // do nothing
                 }
+            }
+        }
+        
+        SwiftyStoreKit.updatedDownloadsHandler = { downloads in
+
+            // contentURL is not nil if downloadState == .finished
+            let contentURLs = downloads.flatMap { $0.contentURL }
+            if contentURLs.count == downloads.count {
+                print("Saving: \(contentURLs)")
+                SwiftyStoreKit.finishTransaction(downloads[0].transaction)
             }
         }
     }

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -33,6 +33,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
 
         completeIAPTransactions()
+        
+        SwiftyStoreKit.updatedDownloadsHandler = { downloads in
+            
+            let finishedDownloadsCount = downloads.filter { $0.downloadState == .finished }.count
+            if finishedDownloadsCount == downloads.count {
+                SwiftyStoreKit.finishTransaction(downloads[0].transaction)
+            }
+        }
 
         return true
     }

--- a/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
+++ b/SwiftyStoreKit-iOS-Demo/AppDelegate.swift
@@ -52,7 +52,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             for purchase in purchases {
                 switch purchase.transaction.transactionState {
                 case .purchased, .restored:
-                    if purchase.needsFinishTransaction {
+                    let downloads = purchase.transaction.downloads
+                    if !downloads.isEmpty {
+                        SwiftyStoreKit.start(downloads)
+                    } else if purchase.needsFinishTransaction {
                         // Deliver content from server, then:
                         SwiftyStoreKit.finishTransaction(purchase.transaction)
                     }

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -132,7 +132,10 @@ class ViewController: UIViewController {
         SwiftyStoreKit.purchaseProduct(appBundleId + "." + purchase.rawValue, atomically: atomically) { result in
             NetworkActivityIndicatorManager.networkOperationFinished()
 
-            if case .success(let purchase) = result {
+            if case .success(let purchase, let downloads) = result {
+                if !downloads.isEmpty {
+                    SwiftyStoreKit.start(downloads)
+                }
                 // Deliver content from server, then:
                 if purchase.needsFinishTransaction {
                     SwiftyStoreKit.finishTransaction(purchase.transaction)
@@ -267,7 +270,7 @@ extension ViewController {
     // swiftlint:disable cyclomatic_complexity
     func alertForPurchaseResult(_ result: PurchaseResult) -> UIAlertController? {
         switch result {
-        case .success(let purchase):
+        case .success(let purchase, _):
             print("Purchase Success: \(purchase.productId)")
             return nil
         case .error(let error):

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -36,7 +36,7 @@ protocol TransactionController {
 }
 
 public enum TransactionResult {
-    case purchased(purchase: PurchaseDetails, downloads: [SKDownload])
+    case purchased(purchase: PurchaseDetails)
     case restored(purchase: Purchase)
     case failed(error: SKError)
 }

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -48,6 +48,11 @@ public protocol PaymentQueue: class {
 
     func add(_ payment: SKPayment)
     
+    func start(_ downloads: [SKDownload])
+    func pause(_ downloads: [SKDownload])
+    func resume(_ downloads: [SKDownload])
+    func cancel(_ downloads: [SKDownload])
+    
     func restoreCompletedTransactions(withApplicationUsername username: String?)
 
     func finishTransaction(_ transaction: SKPaymentTransaction)
@@ -151,6 +156,19 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         paymentQueue.finishTransaction(skTransaction)
     }
     
+    func start(_ downloads: [SKDownload]) {
+        paymentQueue.start(downloads)
+    }
+    func pause(_ downloads: [SKDownload]) {
+        paymentQueue.pause(downloads)
+    }
+    func resume(_ downloads: [SKDownload]) {
+        paymentQueue.resume(downloads)
+    }
+    func cancel(_ downloads: [SKDownload]) {
+        paymentQueue.cancel(downloads)
+    }
+
     var shouldAddStorePaymentHandler: ShouldAddStorePaymentHandler?
     var updatedDownloadsHandler: UpdatedDownloadsHandler?
 

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -36,7 +36,7 @@ protocol TransactionController {
 }
 
 public enum TransactionResult {
-    case purchased(purchase: PurchaseDetails)
+    case purchased(purchase: PurchaseDetails, downloads: [SKDownload])
     case restored(purchase: Purchase)
     case failed(error: SKError)
 }
@@ -47,7 +47,7 @@ public protocol PaymentQueue: class {
     func remove(_ observer: SKPaymentTransactionObserver)
 
     func add(_ payment: SKPayment)
-
+    
     func restoreCompletedTransactions(withApplicationUsername username: String?)
 
     func finishTransaction(_ transaction: SKPaymentTransaction)
@@ -152,6 +152,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
     }
     
     var shouldAddStorePaymentHandler: ShouldAddStorePaymentHandler?
+    var updatedDownloadsHandler: UpdatedDownloadsHandler?
 
     // MARK: SKPaymentTransactionObserver
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
@@ -210,6 +211,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedDownloads downloads: [SKDownload]) {
 
+        updatedDownloadsHandler?(downloads)
     }
 
     func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -74,7 +74,7 @@ class PaymentsController: TransactionController {
         if transactionState == .purchased {
             let purchase = PurchaseDetails(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, product: payment.product, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !payment.atomically)
             
-            payment.callback(.purchased(purchase: purchase, downloads: transaction.downloads))
+            payment.callback(.purchased(purchase: purchase))
 
             if payment.atomically {
                 paymentQueue.finishTransaction(transaction)

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -74,7 +74,7 @@ class PaymentsController: TransactionController {
         if transactionState == .purchased {
             let purchase = PurchaseDetails(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, product: payment.product, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !payment.atomically)
             
-            payment.callback(.purchased(purchase: purchase))
+            payment.callback(.purchased(purchase: purchase, downloads: transaction.downloads))
 
             if payment.atomically {
                 paymentQueue.finishTransaction(transaction)

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -55,6 +55,7 @@ public protocol PaymentTransaction {
     var transactionDate: Date? { get }
     var transactionState: SKPaymentTransactionState { get }
     var transactionIdentifier: String? { get }
+    var downloads: [SKDownload] { get }
 }
 
 // Add PaymentTransaction conformance to SKPaymentTransaction
@@ -69,7 +70,7 @@ public struct RetrieveResults {
 
 // Purchase result
 public enum PurchaseResult {
-    case success(purchase: PurchaseDetails, downloads: [SKDownload])
+    case success(purchase: PurchaseDetails)
     case error(error: SKError)
 }
 

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -69,7 +69,7 @@ public struct RetrieveResults {
 
 // Purchase result
 public enum PurchaseResult {
-    case success(purchase: PurchaseDetails)
+    case success(purchase: PurchaseDetails, downloads: [SKDownload])
     case error(error: SKError)
 }
 
@@ -80,6 +80,7 @@ public struct RestoreResults {
 }
 
 public typealias ShouldAddStorePaymentHandler = (_ payment: SKPayment, _ product: SKProduct) -> Bool
+public typealias UpdatedDownloadsHandler = (_ downloads: [SKDownload]) -> Void
 
 // MARK: Receipt verification
 

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -225,6 +225,19 @@ extension SwiftyStoreKit {
             sharedInstance.paymentQueueController.updatedDownloadsHandler = updatedDownloadsHandler
         }
     }
+    
+    public class func start(_ downloads: [SKDownload]) {
+        sharedInstance.paymentQueueController.start(downloads)
+    }
+    public class func pause(_ downloads: [SKDownload]) {
+        sharedInstance.paymentQueueController.pause(downloads)
+    }
+    public class func resume(_ downloads: [SKDownload]) {
+        sharedInstance.paymentQueueController.resume(downloads)
+    }
+    public class func cancel(_ downloads: [SKDownload]) {
+        sharedInstance.paymentQueueController.cancel(downloads)
+    }
 }
 
 extension SwiftyStoreKit {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -95,8 +95,8 @@ public class SwiftyStoreKit {
 
     private func processPurchaseResult(_ result: TransactionResult) -> PurchaseResult {
         switch result {
-        case .purchased(let purchase, let downloads):
-            return .success(purchase: purchase, downloads: downloads)
+        case .purchased(let purchase):
+            return .success(purchase: purchase)
         case .failed(let error):
             return .error(error: error)
         case .restored(let purchase):
@@ -109,7 +109,7 @@ public class SwiftyStoreKit {
         var restoreFailedPurchases: [(SKError, String?)] = []
         for result in results {
             switch result {
-            case .purchased(let purchase, _):
+            case .purchased(let purchase):
                 let error = storeInternalError(description: "Cannot purchase product \(purchase.productId) from restore purchases path")
                 restoreFailedPurchases.append((error, purchase.productId))
             case .failed(let error):

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -95,8 +95,8 @@ public class SwiftyStoreKit {
 
     private func processPurchaseResult(_ result: TransactionResult) -> PurchaseResult {
         switch result {
-        case .purchased(let purchase):
-            return .success(purchase: purchase)
+        case .purchased(let purchase, let downloads):
+            return .success(purchase: purchase, downloads: downloads)
         case .failed(let error):
             return .error(error: error)
         case .restored(let purchase):
@@ -109,7 +109,7 @@ public class SwiftyStoreKit {
         var restoreFailedPurchases: [(SKError, String?)] = []
         for result in results {
             switch result {
-            case .purchased(let purchase):
+            case .purchased(let purchase, _):
                 let error = storeInternalError(description: "Cannot purchase product \(purchase.productId) from restore purchases path")
                 restoreFailedPurchases.append((error, purchase.productId))
             case .failed(let error):
@@ -214,6 +214,15 @@ extension SwiftyStoreKit {
     public static var shouldAddStorePaymentHandler: ShouldAddStorePaymentHandler? {
         didSet {
             sharedInstance.paymentQueueController.shouldAddStorePaymentHandler = shouldAddStorePaymentHandler
+        }
+    }
+    
+    /**
+     * Register a handler for paymentQueue(_:updatedDownloads:)
+     */
+    public static var updatedDownloadsHandler: UpdatedDownloadsHandler? {
+        didSet {
+            sharedInstance.paymentQueueController.updatedDownloadsHandler = updatedDownloadsHandler
         }
     }
 }

--- a/SwiftyStoreKitTests/PaymentQueueSpy.swift
+++ b/SwiftyStoreKitTests/PaymentQueueSpy.swift
@@ -44,4 +44,20 @@ class PaymentQueueSpy: PaymentQueue {
 
         finishTransactionCalledCount += 1
     }
+    
+    func start(_ downloads: [SKDownload]) {
+        
+    }
+    
+    func pause(_ downloads: [SKDownload]) {
+        
+    }
+    
+    func resume(_ downloads: [SKDownload]) {
+        
+    }
+    
+    func cancel(_ downloads: [SKDownload]) {
+        
+    }
 }


### PR DESCRIPTION
Implementation for #128.

- [x] expose `[SKDownloads]` array on purchase success completion block
- [x] add `updatedDownloadsHandler` block to subscribe to updated downloads callbacks
- [x] add `start`/`pause`/`resume`/`cancel` calls to manage downloads status
- [x] update iOS demo app with usage example
- [x] fix existing unit tests
- [ ] add new unit tests
- [x] update README
- [x] update CHANGELOG