### PR TITLE
Add a wrapper for simulatesAskToBuyInSandbox

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -121,6 +121,13 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         let skPayment = SKMutablePayment(product: payment.product)
         skPayment.applicationUsername = payment.applicationUsername
         skPayment.quantity = payment.quantity
+        
+#if os(iOS) || os(tvOS)
+        if #available(iOS 8.3, tvOS 9.0, *) {
+            skPayment.simulatesAskToBuyInSandbox = payment.simulatesAskToBuyInSandbox
+        }
+#endif
+
         paymentQueue.add(skPayment)
 
         paymentsController.append(payment)

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -30,6 +30,7 @@ struct Payment: Hashable {
     let quantity: Int
     let atomically: Bool
     let applicationUsername: String
+    let simulatesAskToBuyInSandbox: Bool
     let callback: (TransactionResult) -> Void
 
     var hashValue: Int {

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -46,11 +46,11 @@ public class SwiftyStoreKit {
         return productsInfoController.retrieveProductsInfo(productIds, completion: completion)
     }
     
-    fileprivate func purchaseProduct(_ productId: String, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", completion: @escaping ( PurchaseResult) -> Void) {
+    fileprivate func purchaseProduct(_ productId: String, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
 
         retrieveProductsInfo(Set([productId])) { result -> Void in
             if let product = result.retrievedProducts.first {
-                self.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, completion: completion)
+                self.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, completion: completion)
             } else if let error = result.error {
                 completion(.error(error: SKError(_nsError: error as NSError)))
             } else if let invalidProductId = result.invalidProductIDs.first {
@@ -61,14 +61,14 @@ public class SwiftyStoreKit {
         }
     }
 
-    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", completion: @escaping (PurchaseResult) -> Void) {
+    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping (PurchaseResult) -> Void) {
         guard SwiftyStoreKit.canMakePayments else {
             let error = NSError(domain: SKErrorDomain, code: SKError.paymentNotAllowed.rawValue, userInfo: nil)
             completion(.error(error: SKError(_nsError: error)))
             return
         }
         
-        paymentQueueController.startPayment(Payment(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername) { result in
+        paymentQueueController.startPayment(Payment(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
             
             completion(self.processPurchaseResult(result))
         })
@@ -159,9 +159,9 @@ extension SwiftyStoreKit {
      *  - Parameter applicationUsername: an opaque identifier for the user’s account on your system
      *  - Parameter completion: handler for result
      */
-    public class func purchaseProduct(_ productId: String, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", completion: @escaping (PurchaseResult) -> Void) {
+    public class func purchaseProduct(_ productId: String, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping (PurchaseResult) -> Void) {
 
-        sharedInstance.purchaseProduct(productId, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, completion: completion)
+        sharedInstance.purchaseProduct(productId, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, completion: completion)
     }
     
     /**
@@ -172,9 +172,9 @@ extension SwiftyStoreKit {
      *  - Parameter applicationUsername: an opaque identifier for the user’s account on your system
      *  - Parameter completion: handler for result
      */
-    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", completion: @escaping ( PurchaseResult) -> Void) {
+    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
         
-        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, completion: completion)
+        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, completion: completion)
     }
 
     /**

--- a/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
@@ -29,11 +29,12 @@ import StoreKit
 @testable import SwiftyStoreKit
 
 extension Payment {
-    init(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String, callback: @escaping (TransactionResult) -> Void) {
+    init(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String, simulatesAskToBuyInSandbox: Bool, callback: @escaping (TransactionResult) -> Void) {
         self.product = product
         self.quantity = quantity
         self.atomically = atomically
         self.applicationUsername = applicationUsername
+        self.simulatesAskToBuyInSandbox = simulatesAskToBuyInSandbox
         self.callback = callback
     }
 }
@@ -300,6 +301,6 @@ class PaymentQueueControllerTests: XCTestCase {
     func makeTestPayment(productIdentifier: String, quantity: Int = 1, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
         let testProduct = TestProduct(productIdentifier: productIdentifier)
-        return Payment(product: testProduct, quantity: quantity, atomically: atomically, applicationUsername: "", callback: callback)
+        return Payment(product: testProduct, quantity: quantity, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
     }
 }

--- a/SwiftyStoreKitTests/PaymentsControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentsControllerTests.swift
@@ -240,7 +240,7 @@ class PaymentsControllerTests: XCTestCase {
 
     func makeTestPayment(product: SKProduct, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
-        return Payment(product: product, quantity: 1, atomically: atomically, applicationUsername: "", callback: callback)
+        return Payment(product: product, quantity: 1, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
     }
 
     func makeTestPayment(productIdentifier: String, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {


### PR DESCRIPTION
Added a way to use the simulatesAskToBuyInSandbox property of SKMutablePayment (added in iOS 8.3, tvOS 9.0).  This property is intended to allow you to use a sandbox account to test how your app handles the situation where Ask To Buy is turned on for in-app purchases.

Details of Ask To Buy and testing it can be found at:

- https://developer.apple.com/library/content/technotes/tn2259/_index.html#//apple_ref/doc/uid/DTS40009578-CH1-UPDATE_YOUR_APP_FOR_ASK_TO_BUY
- https://stackoverflow.com/questions/42152560/how-to-handle-skpaymenttransactionstatedeferred
- https://stackoverflow.com/questions/25510678/how-to-test-skpaymenttransactionstatedeferred

Unfortunately, from the last stackoverflow discussion, people are reporting that this property doesn't work as expected.  My own testing with the iOS 11.2 SDK confirms this: even when the property is set when using a sandbox account, transactions are never reported in the deferred state.  However, if/when Apple fixes this issue, then this wrapper functionality will allow it to be used.