### PR TITLE
Added new property "isInIntroOfferPeriod" to ReceiptItem

### DIFF
--- a/SwiftyStoreKit/InAppReceipt.swift
+++ b/SwiftyStoreKit/InAppReceipt.swift
@@ -64,6 +64,11 @@ extension ReceiptItem {
         } else {
             self.isTrialPeriod = false
         }
+        if let isInIntroOfferPeriod = receiptInfo["is_in_intro_offer_period"] as? String {
+            self.isInIntroOfferPeriod = Bool(isInIntroOfferPeriod) ?? false
+        } else {
+            self.isInIntroOfferPeriod = false
+        }
     }
 
     private static func parseDate(from receiptInfo: ReceiptInfo, key: String) -> Date? {

--- a/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -139,6 +139,8 @@ public struct ReceiptItem {
     public let cancellationDate: Date?
 
     public let isTrialPeriod: Bool
+    
+    public let isInIntroOfferPeriod: Bool
 }
 
 // Error when managing receipt


### PR DESCRIPTION
See documentation for "Subscription Introductory Price Period" at
https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW25

> For an auto-renewable subscription, whether or not it is in the introductory price period.