### PR TITLE
Update SwiftyStoreKit.swift

### DIFF
--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -57,6 +57,9 @@ public class SwiftyStoreKit {
                 let userInfo = [ NSLocalizedDescriptionKey: "Invalid product id: \(invalidProductId)" ]
                 let error = NSError(domain: SKErrorDomain, code: SKError.paymentInvalid.rawValue, userInfo: userInfo)
                 completion(.error(error: SKError(_nsError: error)))
+            } else {
+                let error = NSError(domain: SKErrorDomain, code: SKError.unknown.rawValue, userInfo: nil)
+                completion(.error(error: SKError(_nsError: error)))
             }
         }
     }


### PR DESCRIPTION
The function purchaseProduct() can leave without calling the completion handler if none of the if-lets will work out. The added lines will call the completion handler with an unknown error.