### PR TITLE
 Added a call back if an unexpected error occurred

### DIFF
--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -95,6 +95,8 @@ class PaymentsController: TransactionController {
         if transactionState == .restored {
             print("Unexpected restored transaction for payment \(transactionProductIdentifier)")
         }
+        
+        payment.callback(.failed(error: transactionError(for: transaction.error as NSError?)))
         return false
     }
 


### PR DESCRIPTION
The function processTransaction() shouldn't be left without calling the completion handler "callback" of the payment object.