### PR TITLE
Removed canMakePayments check on purchase method

### DIFF
--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -65,12 +65,6 @@ public class SwiftyStoreKit {
     }
 
     fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping (PurchaseResult) -> Void) {
-        guard SwiftyStoreKit.canMakePayments else {
-            let error = NSError(domain: SKErrorDomain, code: SKError.paymentNotAllowed.rawValue, userInfo: nil)
-            completion(.error(error: SKError(_nsError: error)))
-            return
-        }
-        
         paymentQueueController.startPayment(Payment(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
             
             completion(self.processPurchaseResult(result))


### PR DESCRIPTION
This check is giving some troubles, returning bad values.
Easy way to check this is setting "Installing Apps" on Itunes & App Store restriction, canMakePayments should return YES, but its returning NO.
We was facing some production users of our app that reported other issues with the same check.
This lead us to a 30% decrease on our purchases.
Since this check is not required because the normal purchase flow will not let you buy anyway if the restrictions are set up, I removed it.

It seems to be related with this issue: https://forums.developer.apple.com/thread/22312