### PR TITLE
Add basic SwiftPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "SwiftyStoreKit",
+    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    products: [
+        .library(name: "SwiftyStoreKit", targets: ["SwiftyStoreKit"])
+    ],
+    targets: [
+        .target(
+            name: "SwiftyStoreKit",
+            path: "SwiftyStoreKit"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Issues](https://img.shields.io/github/issues/bizz84/SwiftyStoreKit.svg?style=flat)](https://github.com/bizz84/SwiftyStoreKit/issues)
 [![Cocoapod](http://img.shields.io/cocoapods/v/SwiftyStoreKit.svg?style=flat)](http://cocoadocs.org/docsets/SwiftyStoreKit/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![Downloads](https://img.shields.io/cocoapods/dm/SwiftyStoreKit.svg)](https://cocoapods.org/pods/SwiftyStoreKit)
 [![Twitter](https://img.shields.io/badge/twitter-@biz84-blue.svg?maxAge=2592000)](http://twitter.com/biz84)
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.