### PR TITLE
Resolved repurchasing a non-consumable not calling completion, on macOS

### DIFF
--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -83,6 +83,21 @@ class PaymentsController: TransactionController {
             payments.remove(at: paymentIndex)
             return true
         }
+
+        if transactionState == .restored {
+            print("Unexpected restored transaction for payment \(transactionProductIdentifier)")
+
+            let purchase = PurchaseDetails(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, product: payment.product, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !payment.atomically)
+
+            payment.callback(.purchased(purchase: purchase))
+
+            if payment.atomically {
+                paymentQueue.finishTransaction(transaction)
+            }
+            payments.remove(at: paymentIndex)
+            return true
+        }
+
         if transactionState == .failed {
 
             payment.callback(.failed(error: transactionError(for: transaction.error as NSError?)))
@@ -92,9 +107,6 @@ class PaymentsController: TransactionController {
             return true
         }
 
-        if transactionState == .restored {
-            print("Unexpected restored transaction for payment \(transactionProductIdentifier)")
-        }
         return false
     }
 


### PR DESCRIPTION
Resolved repurchasing a non-consumable not calling completion, on macOS