### PR TITLE
Add "Sluggard: Break Reminder" to list of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,7 @@ It would be great to showcase apps using SwiftyStoreKit here. Pull requests welc
 * [Zmeu Grand Canyon](http://grandcanyon.zmeu.guide/) - Interactive hiking map & planner
 * [OB Monitor](https://itunes.apple.com/app/id1073398446) - The app for Texas Longhorns athletics fans
 * [Talk Dim Sum](https://itunes.apple.com/us/app/talk-dim-sum/id953929066) - Your dim sum companion
+* [Sluggard](https://itunes.apple.com/app/id1160131071) - Perform simple exercises to reduce the risks of sedentary lifestyle
 
 A full list of apps is published [on AppSight](https://www.appsight.io/sdk/574154).
 


### PR DESCRIPTION
Added Sluggard to the "Apps using SwiftyStoreKit" section.