### PR TITLE
UIKit for Mac build fix

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -240,7 +240,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         updatedDownloadsHandler?(downloads)
     }
 
-    #if os(iOS)
+    #if os(iOS) && !targetEnvironment(UIKitForMac)
     func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
         
         return shouldAddStorePaymentHandler?(payment, product) ?? false


### PR DESCRIPTION
The [paymentQueue(_:shouldAddStorePayment:for:)](https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/2877502-paymentqueue) instance method is not available on UIKit for Mac and because of that we need to filter it out in order to compile.