### PR TITLE
Hot Fix: macOS Catalyst macro change to allow building

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -240,7 +240,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         updatedDownloadsHandler?(downloads)
     }
 
-    #if os(iOS) && !targetEnvironment(UIKitForMac)
+    #if os(iOS) && !targetEnvironment(macCatalyst)
     func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
         
         return shouldAddStorePaymentHandler?(payment, product) ?? false


### PR DESCRIPTION
Fix for change in macOS Catalyst macro. The project should now work in Catalyst builds (particularly when attempting to compile with CocoaPods).

May help with #484 