### PR TITLE
Added support for Subscription Offers

### DIFF
--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -123,6 +123,17 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         skPayment.applicationUsername = payment.applicationUsername
         skPayment.quantity = payment.quantity
         
+        if #available(iOS 12.2, tvOS 12.2, *) {
+            
+            if let obj = payment.discount, !(obj is SKPaymentDiscount) {
+                assert(false, "Unrecognized type provided for payment discount. Only SKPaymentDiscount is supported")
+            }
+            
+            if let discount = payment.discount as? SKPaymentDiscount {
+                skPayment.paymentDiscount = discount
+            }
+        }
+        
 #if os(iOS) || os(tvOS)
         if #available(iOS 8.3, tvOS 9.0, *) {
             skPayment.simulatesAskToBuyInSandbox = payment.simulatesAskToBuyInSandbox

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -125,11 +125,11 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         
         if #available(iOS 12.2, tvOS 12.2, *) {
             
-            if let obj = payment.discount, !(obj is SKPaymentDiscount) {
+            if let obj = payment.paymentDiscount, !(obj is SKPaymentDiscount) {
                 assert(false, "Unrecognized type provided for payment discount. Only SKPaymentDiscount is supported")
             }
             
-            if let discount = payment.discount as? SKPaymentDiscount {
+            if let discount = payment.paymentDiscount as? SKPaymentDiscount {
                 skPayment.paymentDiscount = discount
             }
         }

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -123,7 +123,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         skPayment.applicationUsername = payment.applicationUsername
         skPayment.quantity = payment.quantity
         
-        if #available(iOS 12.2, tvOS 12.2, *) {
+        if #available(iOS 12.2, tvOS 12.2, OSX 10.14.4, *) {
             
             if let discount = payment.paymentDiscount?.discount as? SKPaymentDiscount {
                 skPayment.paymentDiscount = discount

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -125,11 +125,7 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         
         if #available(iOS 12.2, tvOS 12.2, *) {
             
-            if let obj = payment.paymentDiscount, !(obj is SKPaymentDiscount) {
-                assert(false, "Unrecognized type provided for payment discount. Only SKPaymentDiscount is supported")
-            }
-            
-            if let discount = payment.paymentDiscount as? SKPaymentDiscount {
+            if let discount = payment.paymentDiscount?.discount as? SKPaymentDiscount {
                 skPayment.paymentDiscount = discount
             }
         }

--- a/SwiftyStoreKit/PaymentQueueController.swift
+++ b/SwiftyStoreKit/PaymentQueueController.swift
@@ -124,7 +124,6 @@ class PaymentQueueController: NSObject, SKPaymentTransactionObserver {
         skPayment.quantity = payment.quantity
         
         if #available(iOS 12.2, tvOS 12.2, OSX 10.14.4, *) {
-            
             if let discount = payment.paymentDiscount?.discount as? SKPaymentDiscount {
                 skPayment.paymentDiscount = discount
             }

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -52,7 +52,7 @@ public struct PaymentDiscount {
     let discount: AnyObject
     
     @available(iOS 12.2, *)
-    init(discount: SKPaymentDiscount) {
+    public init(discount: SKPaymentDiscount) {
         self.discount = discount
     }
 }

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -51,7 +51,7 @@ struct Payment: Hashable {
 public struct PaymentDiscount {
     let discount: AnyObject
     
-    @available(iOS 12.2, *)
+    @available(iOS 12.2, tvOS 12.2, OSX 10.14.4, *)
     public init(discount: SKPaymentDiscount) {
         self.discount = discount
     }

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -29,7 +29,7 @@ struct Payment: Hashable {
     let product: SKProduct
     
     /// SKPaymentDiscount
-    let discount: NSObject?
+    let paymentDiscount: AnyObject?
     let quantity: Int
     let atomically: Bool
     let applicationUsername: String

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -27,6 +27,9 @@ import StoreKit
 
 struct Payment: Hashable {
     let product: SKProduct
+    
+    /// SKPaymentDiscount
+    let discount: NSObject?
     let quantity: Int
     let atomically: Bool
     let applicationUsername: String

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -49,11 +49,15 @@ struct Payment: Hashable {
 }
 
 public struct PaymentDiscount {
-    let discount: AnyObject
+    let discount: AnyObject?
     
     @available(iOS 12.2, tvOS 12.2, OSX 10.14.4, *)
     public init(discount: SKPaymentDiscount) {
         self.discount = discount
+    }
+    
+    private init() {
+        self.discount = nil
     }
 }
 

--- a/SwiftyStoreKit/PaymentsController.swift
+++ b/SwiftyStoreKit/PaymentsController.swift
@@ -28,8 +28,7 @@ import StoreKit
 struct Payment: Hashable {
     let product: SKProduct
     
-    /// SKPaymentDiscount
-    let paymentDiscount: AnyObject?
+    let paymentDiscount: PaymentDiscount?
     let quantity: Int
     let atomically: Bool
     let applicationUsername: String
@@ -46,6 +45,15 @@ struct Payment: Hashable {
     
     static func == (lhs: Payment, rhs: Payment) -> Bool {
         return lhs.product.productIdentifier == rhs.product.productIdentifier
+    }
+}
+
+public struct PaymentDiscount {
+    let discount: AnyObject
+    
+    @available(iOS 12.2, *)
+    init(discount: SKPaymentDiscount) {
+        self.discount = discount
     }
 }
 

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -64,7 +64,7 @@ public class SwiftyStoreKit {
         }
     }
 
-    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: AnyObject? = nil, completion: @escaping (PurchaseResult) -> Void) {
+    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: PaymentDiscount? = nil, completion: @escaping (PurchaseResult) -> Void) {
         paymentQueueController.startPayment(Payment(product: product, paymentDiscount: paymentDiscount, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
             
             completion(self.processPurchaseResult(result))
@@ -170,7 +170,7 @@ extension SwiftyStoreKit {
      *  - Parameter product: optional discount to be applied. Must be SKProductPayment type
      *  - Parameter completion: handler for result
      */
-    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: AnyObject? = nil, completion: @escaping ( PurchaseResult) -> Void) {
+    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: PaymentDiscount? = nil, completion: @escaping ( PurchaseResult) -> Void) {
         
         sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, paymentDiscount: paymentDiscount, completion: completion)
     }

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -64,8 +64,8 @@ public class SwiftyStoreKit {
         }
     }
 
-    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping (PurchaseResult) -> Void) {
-        paymentQueueController.startPayment(Payment(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
+    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, discount: NSObject? = nil, completion: @escaping (PurchaseResult) -> Void) {
+        paymentQueueController.startPayment(Payment(product: product, discount: discount, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
             
             completion(self.processPurchaseResult(result))
         })
@@ -172,6 +172,21 @@ extension SwiftyStoreKit {
     public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
         
         sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, completion: completion)
+    }
+    
+    /**
+     *  Purchase a product with discount
+     *  - Parameter product: product to be purchased
+     *  - Parameter product: optional discount to be applied
+     *  - Parameter quantity: quantity of the product to be purchased
+     *  - Parameter atomically: whether the product is purchased atomically (e.g. finishTransaction is called immediately)
+     *  - Parameter applicationUsername: an opaque identifier for the user’s account on your system
+     *  - Parameter completion: handler for result
+     */
+    @available(iOS 12.2, tvOS 12.2, *)
+    public class func purchaseProductWithDiscount(_ product: SKProduct, discount: SKPaymentDiscount?, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
+        
+        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, discount: discount, completion: completion)
     }
 
     /**

--- a/SwiftyStoreKit/SwiftyStoreKit.swift
+++ b/SwiftyStoreKit/SwiftyStoreKit.swift
@@ -64,8 +64,8 @@ public class SwiftyStoreKit {
         }
     }
 
-    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, discount: NSObject? = nil, completion: @escaping (PurchaseResult) -> Void) {
-        paymentQueueController.startPayment(Payment(product: product, discount: discount, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
+    fileprivate func purchase(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: AnyObject? = nil, completion: @escaping (PurchaseResult) -> Void) {
+        paymentQueueController.startPayment(Payment(product: product, paymentDiscount: paymentDiscount, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox) { result in
             
             completion(self.processPurchaseResult(result))
         })
@@ -167,26 +167,12 @@ extension SwiftyStoreKit {
      *  - Parameter quantity: quantity of the product to be purchased
      *  - Parameter atomically: whether the product is purchased atomically (e.g. finishTransaction is called immediately)
      *  - Parameter applicationUsername: an opaque identifier for the user’s account on your system
+     *  - Parameter product: optional discount to be applied. Must be SKProductPayment type
      *  - Parameter completion: handler for result
      */
-    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
+    public class func purchaseProduct(_ product: SKProduct, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, paymentDiscount: AnyObject? = nil, completion: @escaping ( PurchaseResult) -> Void) {
         
-        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, completion: completion)
-    }
-    
-    /**
-     *  Purchase a product with discount
-     *  - Parameter product: product to be purchased
-     *  - Parameter product: optional discount to be applied
-     *  - Parameter quantity: quantity of the product to be purchased
-     *  - Parameter atomically: whether the product is purchased atomically (e.g. finishTransaction is called immediately)
-     *  - Parameter applicationUsername: an opaque identifier for the user’s account on your system
-     *  - Parameter completion: handler for result
-     */
-    @available(iOS 12.2, tvOS 12.2, *)
-    public class func purchaseProductWithDiscount(_ product: SKProduct, discount: SKPaymentDiscount?, quantity: Int = 1, atomically: Bool = true, applicationUsername: String = "", simulatesAskToBuyInSandbox: Bool = false, completion: @escaping ( PurchaseResult) -> Void) {
-        
-        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, discount: discount, completion: completion)
+        sharedInstance.purchase(product: product, quantity: quantity, atomically: atomically, applicationUsername: applicationUsername, simulatesAskToBuyInSandbox: simulatesAskToBuyInSandbox, paymentDiscount: paymentDiscount, completion: completion)
     }
 
     /**

--- a/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentQueueControllerTests.swift
@@ -29,7 +29,8 @@ import StoreKit
 @testable import SwiftyStoreKit
 
 extension Payment {
-    init(product: SKProduct, quantity: Int, atomically: Bool, applicationUsername: String, simulatesAskToBuyInSandbox: Bool, callback: @escaping (TransactionResult) -> Void) {
+    init(product: SKProduct, paymentDiscount: PaymentDiscount, quantity: Int, atomically: Bool, applicationUsername: String, simulatesAskToBuyInSandbox: Bool, callback: @escaping (TransactionResult) -> Void) {
+        self.paymentDiscount = paymentDiscount
         self.product = product
         self.quantity = quantity
         self.atomically = atomically
@@ -301,6 +302,6 @@ class PaymentQueueControllerTests: XCTestCase {
     func makeTestPayment(productIdentifier: String, quantity: Int = 1, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
         let testProduct = TestProduct(productIdentifier: productIdentifier)
-        return Payment(product: testProduct, quantity: quantity, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
+        return Payment(product: testProduct, paymentDiscount: nil, quantity: quantity, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
     }
 }

--- a/SwiftyStoreKitTests/PaymentsControllerTests.swift
+++ b/SwiftyStoreKitTests/PaymentsControllerTests.swift
@@ -240,7 +240,7 @@ class PaymentsControllerTests: XCTestCase {
 
     func makeTestPayment(product: SKProduct, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {
 
-        return Payment(product: product, quantity: 1, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
+        return Payment(product: product, paymentDiscount: nil, quantity: 1, atomically: atomically, applicationUsername: "", simulatesAskToBuyInSandbox: false, callback: callback)
     }
 
     func makeTestPayment(productIdentifier: String, atomically: Bool = true, callback: @escaping (TransactionResult) -> Void) -> Payment {


### PR DESCRIPTION
I've decided to use simple struct `PaymentDiscount` to wrap around `SKPaymentDiscount` available only on  >= iOS 12.2

This means that the method  `func purchase(...` can be called without `#available(...`

Fixes #458