### PR TITLE
swiftpm: set minimum target versions - allows deployment to watchos

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
     name: "SwiftyStoreKit",
-    // platforms: [.iOS("8.0"), .macOS("10.10"), tvOS("9.0"), .watchOS("2.0")],
+    platforms: [.iOS("8.0"), .macOS("10.10"), .tvOS("9.0"), .watchOS("6.2")],
     products: [
         .library(name: "SwiftyStoreKit", targets: ["SwiftyStoreKit"])
     ],


### PR DESCRIPTION
We need to set the minimum target versions supported in Package.swift - otherwise cannot build against watchos when imported with swiftpm, because the minimum target version has to be set to 6.2 as that's when the storekit apis where introduced.

thank you for the library!