### PR TITLE
Adds Hashr to showcase apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,7 @@ It would be great to showcase apps using SwiftyStoreKit here. Pull requests welc
 * [Talk Dim Sum](https://itunes.apple.com/us/app/talk-dim-sum/id953929066) - Your dim sum companion
 * [Sluggard](https://itunes.apple.com/app/id1160131071) - Perform simple exercises to reduce the risks of sedentary lifestyle
 * [Debts iOS](https://debts.ivanvorobei.by/ios) & [Debts macOS](https://debts.ivanvorobei.by/macos) - Track amounts owed
+* [Hashr](https://apps.apple.com/app/id1166499829) - Generate unique password hashes based on website and master password
 
 A full list of apps is published [on AppSight](https://www.appsight.io/sdk/574154).
 


### PR DESCRIPTION
The iOS app "Hashr" uses SwiftyStoreKit for 3 years. This will add this app to the showcase apps.