### PR TITLE
Add support for interrupted transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 * Make `ProductsInfoController`'s `retrieveProductsInfo` thread safe ([#405]https://github.com/bizz84/SwiftyStoreKit/pull/495), related issues: [#344](https://github.com/bizz84/SwiftyStoreKit/issues/344) and [#468](https://github.com/bizz84/SwiftyStoreKit/issues/468)
+* Add support for interrupted purchases ([#615](https://github.com/bizz84/SwiftyStoreKit/pull/615)), related issues: [#593](https://github.com/bizz84/SwiftyStoreKit/issues/593) and [#606](https://github.com/bizz84/SwiftyStoreKit/issues/606)
 
 ## [0.15.0](https://github.com/bizz84/SwiftyStoreKit/releases/tag/0.15.0) Update project to Swift 5, Xcode 10.2
 

--- a/Sources/SwiftyStoreKit/PaymentsController.swift
+++ b/Sources/SwiftyStoreKit/PaymentsController.swift
@@ -174,7 +174,7 @@ class PaymentsController: TransactionController {
 }
 
 private extension Array where Element == Payment {
-  func firstIndex(withProductIdentifier identifier: String) -> Int? {
-     return firstIndex { $0.product.productIdentifier == identifier }
-  }
+    func firstIndex(withProductIdentifier identifier: String) -> Int? {
+        return firstIndex { $0.product.productIdentifier == identifier }
+    }
 }

--- a/Sources/SwiftyStoreKit/PaymentsController.swift
+++ b/Sources/SwiftyStoreKit/PaymentsController.swift
@@ -66,20 +66,8 @@ class PaymentsController: TransactionController {
     private var payments: [Payment] = []
     private var failedPayments: [Payment] = []
 
-    private func findPaymentIndex(withProductIdentifier identifier: String) -> Int? {
-        return payments.enumerated()
-            .first { $0.element.product.productIdentifier == identifier }
-            .map { $0.offset }
-    }
-
-    private func findFailedPaymentIndex(withProductIdentifier identifier: String) -> Int? {
-        return failedPayments.enumerated()
-            .first { $0.element.product.productIdentifier == identifier }
-            .map { $0.offset }
-    }
-
     func hasPayment(_ payment: Payment) -> Bool {
-        return findPaymentIndex(withProductIdentifier: payment.product.productIdentifier) != nil
+        return payments.firstIndex(withProductIdentifier: payment.product.productIdentifier) != nil
     }
 
     func append(_ payment: Payment) {
@@ -157,7 +145,7 @@ class PaymentsController: TransactionController {
         let transactionProductIdentifier = transaction.payment.productIdentifier
         let transactionState = transaction.transactionState
 
-        if let paymentIndex = findPaymentIndex(withProductIdentifier: transactionProductIdentifier) {
+        if let paymentIndex = payments.firstIndex(withProductIdentifier: transactionProductIdentifier) {
             return PaymentHandler(
                 payment: payments[paymentIndex],
                 cleanup: {
@@ -170,7 +158,7 @@ class PaymentsController: TransactionController {
         // it's already sent one with failed, so we need to keep track of failed transactions
         // See https://developer.apple.com/documentation/storekit/in-app_purchase/testing_in-app_purchases_with_sandbox
         if transactionState == .purchased,
-           let failedPaymentIndex = findFailedPaymentIndex(withProductIdentifier: transactionProductIdentifier),
+           let failedPaymentIndex = failedPayments.firstIndex(withProductIdentifier: transactionProductIdentifier),
            case let payment = failedPayments[failedPaymentIndex],
            payment.quantity == transaction.payment.quantity {
             return PaymentHandler(
@@ -183,4 +171,10 @@ class PaymentsController: TransactionController {
 
         return nil
     }
+}
+
+private extension Array where Element == Payment {
+  func firstIndex(withProductIdentifier identifier: String) -> Int? {
+     return firstIndex { $0.product.productIdentifier == identifier }
+  }
 }


### PR DESCRIPTION
#### Summary

Seems related to #593 and #606.

Per documentation provided by https://developer.apple.com/documentation/storekit/in-app_purchase/testing_in-app_purchases_with_sandbox, interrupted purchases will send two transaction notifications for a given purchase:
1. a `.failed` state as the interruption begins
2. a `.success` state afterwards with matching product identifier and quantity

This diff attempts to account for this flow, which would end tracking for a particular purchase attempt on its first failure

#### Notes

I haven't been able to test this flow to completion using the Sandbox environment, since "Accept"-ing terms doesn't seem to trigger a successful transaction in the payment queue. I'd appreciate any assistance in understanding how to test this flow, or if a Feedback to Apple may be in order. (Update: See note below)

Update: Use a relatively new Sandbox tester account for testing the "Interrupted Purchases" flow, as it seems older accounts run into issues where the purchase is never made successful after accepting terms.