### PR TITLE
Added functionality for offer codes using presentCodeRedemptionSheet()

### DIFF
--- a/Sources/SwiftyStoreKit/CodeRedemptionControlller.swift
+++ b/Sources/SwiftyStoreKit/CodeRedemptionControlller.swift
@@ -1,0 +1,79 @@
+import Foundation
+import StoreKit
+
+struct CodeRedemption: Hashable {
+    
+    let atomically: Bool
+    let callback: (TransactionResult) -> Void
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(atomically)
+    }
+    
+    static func == (lhs: CodeRedemption, rhs: CodeRedemption) -> Bool {
+        return true
+    }
+}
+
+class CodeRedemptionController: TransactionController {
+
+    private var codeRedemption: CodeRedemption?
+
+    func set(_ codeRedemption: CodeRedemption) {
+        self.codeRedemption = codeRedemption
+    }
+    
+    func clearCodeRedemption() {
+        self.codeRedemption = nil
+    }
+
+    func processTransaction(_ transaction: SKPaymentTransaction, on paymentQueue: PaymentQueue) -> Bool {
+
+        let transactionProductIdentifier = transaction.payment.productIdentifier
+
+        guard let codeRedemption = self.codeRedemption else {
+
+            return false
+        }
+        
+        let transactionState = transaction.transactionState
+
+        if transactionState == .purchased {
+            let purchase = PurchaseCodeRedemptionDetails(productId: transactionProductIdentifier, quantity: transaction.payment.quantity, transaction: transaction, originalTransaction: transaction.original, needsFinishTransaction: !codeRedemption.atomically)
+            
+            codeRedemption.callback(.redeemed(purchase: purchase))
+
+            if codeRedemption.atomically {
+                paymentQueue.finishTransaction(transaction)
+            }
+            
+            self.clearCodeRedemption()
+            return true
+        }
+
+        if transactionState == .failed {
+
+            codeRedemption.callback(.failed(error: transactionError(for: transaction.error as NSError?)))
+
+            paymentQueue.finishTransaction(transaction)
+            
+            self.clearCodeRedemption()
+            return true
+        }
+
+        self.clearCodeRedemption()
+        return false
+    }
+
+    func transactionError(for error: NSError?) -> SKError {
+        let message = "Unknown error"
+        let altError = NSError(domain: SKErrorDomain, code: SKError.unknown.rawValue, userInfo: [ NSLocalizedDescriptionKey: message ])
+        let nsError = error ?? altError
+        return SKError(_nsError: nsError)
+    }
+
+    func processTransactions(_ transactions: [SKPaymentTransaction], on paymentQueue: PaymentQueue) -> [SKPaymentTransaction] {
+
+        return transactions.filter { !processTransaction($0, on: paymentQueue) }
+    }
+}

--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -96,6 +96,23 @@ public struct PurchaseDetails {
     }
 }
 
+/// Purchased product with offer code
+public struct PurchaseCodeRedemptionDetails {
+    public let productId: String
+    public let quantity: Int
+    public let transaction: PaymentTransaction
+    public let originalTransaction: PaymentTransaction?
+    public let needsFinishTransaction: Bool
+    
+    public init(productId: String, quantity: Int, transaction: PaymentTransaction, originalTransaction: PaymentTransaction?, needsFinishTransaction: Bool) {
+        self.productId = productId
+        self.quantity = quantity
+        self.transaction = transaction
+        self.originalTransaction = originalTransaction
+        self.needsFinishTransaction = needsFinishTransaction
+    }
+}
+
 /// Conform to this protocol to provide custom receipt validator
 public protocol ReceiptValidator {
 	func validate(receiptData: Data, completion: @escaping (VerifyReceiptResult) -> Void)
@@ -128,6 +145,12 @@ public struct RetrieveResults {
 /// Purchase result
 public enum PurchaseResult {
     case success(purchase: PurchaseDetails)
+    case error(error: SKError)
+}
+
+/// CodeRedemption result
+public enum CodeRedemptionResult {
+    case redeemed(purchase: PurchaseCodeRedemptionDetails)
     case error(error: SKError)
 }
 


### PR DESCRIPTION
Added functionality to redeem offer codes using presentCodeRedemptionSheet() #600 https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/implementing_offer_codes_in_your_app

The redemption process will be like the purchase process, when all the flow occurs outside our app and we have no control, it will be observed in PaymentQueueController (func paymentQueue (_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction])) that Apple call this observer after the code redemption has been successful, Apple will only call this observer if the code redemption was successful and using the version of the app that is published in the AppStore (with any other version Apple does not call to this observer).

When Apple calls our observer, the transaction will be processed and the previously configured completion will be called to return control to our app.

This offer code redemption process is tested and working with a version of the app published on the AppStore.