### PR TITLE
Support for "Billing Grace Period"

### DIFF
--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -256,6 +256,9 @@ public enum ReceiptError: Swift.Error {
 /// A pending renewal may refer to a renewal that the system scheduled in the future or a renewal that failed in the past for some reason.
 public struct PendingRenewalInfo: Codable {
     
+    ///The key of the pending renewal array in the response body of the app store receipt
+    public static let KEY_IN_RESPONSE_BODY: String = "pending_renewal_info"
+    
     ///The value for this key corresponds to the productIdentifier property of the product that the customer’s subscription renews.
     public let autoRenewProductId: String
     

--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -172,6 +172,7 @@ public enum VerifyPurchaseResult {
 public enum VerifySubscriptionResult {
     case purchased(expiryDate: Date, items: [ReceiptItem])
     case expired(expiryDate: Date, items: [ReceiptItem])
+    case inGracePeriod(endDate: Date, items: [ReceiptItem], pendingRenewals: [PendingRenewalInfo])
     case notPurchased
 }
 

--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -250,6 +250,110 @@ public enum ReceiptError: Swift.Error {
     case receiptInvalid(receipt: ReceiptInfo, status: ReceiptStatus)
 }
 
+/// Pending renewal as defined here: (https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info)
+/// - Contains the pending renewal information for a ato-renewable subscription identified by the product_id.
+/// A pending renewal may refer to a renewal that the system scheduled in the future or a renewal that failed in the past for some reason.
+public struct PendingRenewalInfo: Codable {
+    
+    ///The value for this key corresponds to the productIdentifier property of the product that the customer’s subscription renews.
+    public let autoRenewProductId: String
+    
+    ///The current renewal status for the auto-renewable subscription.
+    public let autoRenewStatus: AutoRenewStatus
+    
+    ///The reason a subscription expired. This field is only present for a receipt that contains an expired auto-renewable subscription.
+    public let expirationIntent: ExpirationIntent?
+    
+    ///The time at which the grace period for subscription renewals expires, in a date-time format similar to the ISO 8601.
+    public let gracePeriodExpiresDate: String?
+    
+    ///The time at which the grace period for subscription renewals expires, in UNIX epoch time format, in milliseconds.
+    ///This key is only present for apps that have Billing Grace Period enabled and when the user experiences a billing error at the time of renewal. Use this time format for processing dates.
+    public let gracePeriodExpiresDateMS: String?
+    
+    ///The time at which the grace period for subscription renewals expires, in the Pacific Time zone.
+    public let gracePeriodExpiresDatePST: String?
+    
+    ///A flag that indicates Apple is attempting to renew an expired subscription automatically. This field is only present if an auto-renewable subscription is in the billing retry state.
+    public let isInBillingRetryPeriod: BillingRetryPeriod?
+    
+    ///The reference name of a subscription offer that you configured in App Store Connect. This field is present when a customer redeemed a subscription offer code.
+    public let offerCodeRefName: String?
+    
+    ///The transaction identifier of the original purchase.
+    public let originalTransactionId: String
+    
+    ///The price consent status for a subscription price increase. This field is only present if the customer was notified of the price increase.
+    public let priceConsentStatus: PriceConsentStatus?
+    
+    ///The unique identifier of the product purchased. You provide this value when creating the product in App Store Connect,
+    ///and it corresponds to the productIdentifier property of the SKPayment object stored in the transaction's payment property.
+    public let productId: String
+    
+    ///The identifier of the promotional offer for an auto-renewable subscription that the user redeemed.
+    ///You provide this value in the Promotional Offer Identifier field when you create the promotional offer in App Store Connect.
+    public let promotionalOfferId: String?
+    
+    ///Convenience method to retrieve the expiry date of the grace period
+    public var gracePeriodExpiresDateMSToDate: Date? {
+        guard let string = gracePeriodExpiresDateMS else { return nil }
+        return Date(millisecondsSince1970: string)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case autoRenewProductId = "auto_renew_product_id"
+        case autoRenewStatus = "auto_renew_status"
+        case expirationIntent = "expiration_intent"
+        case gracePeriodExpiresDate = "grace_period_expires_date"
+        case gracePeriodExpiresDateMS = "grace_period_expires_date_ms"
+        case gracePeriodExpiresDatePST = "grace_period_expires_date_pst"
+        case isInBillingRetryPeriod = "is_in_billing_retry_period"
+        case offerCodeRefName = "offer_code_ref_name"
+        case originalTransactionId = "original_transaction_id"
+        case priceConsentStatus = "price_consent_status"
+        case productId = "product_id"
+        case promotionalOfferId = "promotional_offer_id"
+    }
+    
+    ///Auto Renew Status defined here: (https://developer.apple.com/documentation/appstorereceipts/auto_renew_status)
+    public enum AutoRenewStatus: String, Codable {
+        ///The subscription will renew at the end of the current subscription period
+        case willRenew = "1"
+        ///The customer has turned off automatic renewal for the subscription.
+        case willNotRenew = "0"
+    }
+    
+    ///Expiration intent defined here: (https://developer.apple.com/documentation/appstorereceipts/auto_renew_status)
+    public enum ExpirationIntent: String, Codable {
+        ///The customer voluntarily canceled their subscription.
+        case subscriptionCanceled = "1"
+        ///Billing error; for example, the customer's payment information was no longer valid.
+        case billingError = "2"
+        ///The customer did not agree to a recent price increase.
+        case declinedPriceIncrease = "3"
+        ///The product was not available for purchase at the time of renewal.
+        case productWasUnavailable = "4"
+        ///Unknown error.
+        case unknown = "5"
+    }
+    
+    ///Billing Retry Period defined here: (https://developer.apple.com/documentation/appstorereceipts/is_in_billing_retry_period)
+    public enum BillingRetryPeriod: String, Codable {
+        ///The App Store is attempting to renew the subscription.
+        case isAttempting = "1"
+        ///The App Store has stopped attempting to renew the subscription.
+        case stoppedAttempting = "0"
+    }
+    
+    ///Documented as follows:
+    ///The default value is "0" and changes to "1" if the customer consents.
+    ///Possible values: 1, 0
+    public enum PriceConsentStatus: String, Codable {
+        case userDidNotConsent = "0"
+        case userDidConsent = "1"
+    }
+}
+
 /// Status code returned by remote server
 /// 
 /// See Table 2-1  Status codes

--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -353,6 +353,21 @@ public struct PendingRenewalInfo: Codable {
         case userDidNotConsent = "0"
         case userDidConsent = "1"
     }
+    
+    public init(autoRenewProductId: String, autoRenewStatus: AutoRenewStatus, expirationIntent: ExpirationIntent?, gracePeriodExpiresDate: String?, gracePeriodExpiresDateMS: String?, gracePeriodExpiresDatePST: String?, isInBillingRetryPeriod: BillingRetryPeriod?, offerCodeRefName: String?, originalTransactionId: String, priceConsentStatus: PriceConsentStatus?, productId: String, promotionalOfferId: String?) {
+        self.autoRenewProductId = autoRenewProductId
+        self.autoRenewStatus = autoRenewStatus
+        self.expirationIntent = expirationIntent
+        self.gracePeriodExpiresDate = gracePeriodExpiresDate
+        self.gracePeriodExpiresDateMS = gracePeriodExpiresDateMS
+        self.gracePeriodExpiresDatePST = gracePeriodExpiresDatePST
+        self.isInBillingRetryPeriod = isInBillingRetryPeriod
+        self.offerCodeRefName = offerCodeRefName
+        self.originalTransactionId = originalTransactionId
+        self.priceConsentStatus = priceConsentStatus
+        self.productId = productId
+        self.promotionalOfferId = promotionalOfferId
+    }
 }
 
 /// Status code returned by remote server

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -344,6 +344,9 @@ extension ViewController {
         case .purchased(let expiryDate, let items):
             print("\(productIds) is valid until \(expiryDate)\n\(items)\n")
             return alertWithTitle("Product is purchased", message: "Product is valid until \(expiryDate)")
+        case .inGracePeriod(let endDate, let items, let pendingRenewals):
+            print("\(productIds) is in grace period until \(endDate)\n\(items)\n\(pendingRenewals)\n")
+            return alertWithTitle("Product is purchased (grace period)", message: "Product is in grace period until \(endDate)")
         case .expired(let expiryDate, let items):
             print("\(productIds) is expired since \(expiryDate)\n\(items)\n")
             return alertWithTitle("Product expired", message: "Product is expired since \(expiryDate)")

--- a/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
+++ b/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
@@ -455,22 +455,26 @@ class InAppReceiptTests: XCTestCase {
     }
 
     // MARK: Helper methods
-    func makeReceipt(items: [ReceiptItem], requestDate: Date) -> [String: AnyObject] {
+    func makeReceipt(items: [ReceiptItem], requestDate: Date, pendingRenewals: [PendingRenewalInfo] = []) -> [String: AnyObject] {
         let receiptInfos = items.map { $0.receiptInfo }
+        let renewalReceiptInfos = pendingRenewals.map { $0.receiptInfo }
 
         // Creating this with NSArray results in __NSSingleObjectArrayI which fails the cast to [String: AnyObject]
         let array = NSMutableArray()
         array.addObjects(from: receiptInfos)
+        
+        let arrayRenewables = NSMutableArray()
+        arrayRenewables.addObjects(from: renewalReceiptInfos)
 
         return [
-            //"latest_receipt": [:],
             "status": "200" as NSString,
             "environment": "Sandbox" as NSString,
             "receipt": NSDictionary(dictionary: [
                 "request_date_ms": requestDate.timeIntervalSince1970.millisecondsNSString,
                 "in_app": array // non renewing
             ]),
-            "latest_receipt_info": array // autoRenewable
+            "latest_receipt_info": array, // autoRenewable
+            PendingRenewalInfo.KEY_IN_RESPONSE_BODY: arrayRenewables //autoRenewable in case of grace period active
         ]
     }
 

--- a/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
+++ b/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
@@ -81,6 +81,33 @@ extension ReceiptItem: Equatable {
     }
 }
 
+extension PendingRenewalInfo: Equatable {
+    init(productId: String, expiryDate: Date, originalTransactionId: String) {
+        self.init(autoRenewProductId: productId, autoRenewStatus: .willRenew, expirationIntent: nil, gracePeriodExpiresDate: nil, gracePeriodExpiresDateMS: expiryDate.timeIntervalSince1970.millisecondsNSString as String, gracePeriodExpiresDatePST: nil, isInBillingRetryPeriod: nil, offerCodeRefName: nil, originalTransactionId: originalTransactionId, priceConsentStatus: nil, productId: productId, promotionalOfferId: nil)
+    }
+    
+    var receiptInfo: NSDictionary {
+        var result: [String: AnyObject] = [
+            "auto_renew_product_id": productId as NSString,
+            "auto_renew_status": autoRenewStatus.rawValue as NSString,
+            "product_id": productId as NSString,
+            "original_transaction_id": originalTransactionId as NSString
+        ]
+        if let gracePeriodExpiresDateMS = gracePeriodExpiresDateMS {
+            result["grace_period_expires_date_ms"] = gracePeriodExpiresDateMS as NSString
+        }
+        return NSDictionary(dictionary: result)
+    }
+    
+    public static func == (lhs: PendingRenewalInfo, rhs: PendingRenewalInfo) -> Bool {
+        return
+            lhs.productId == rhs.productId &&
+            lhs.autoRenewProductId == rhs.autoRenewProductId &&
+            lhs.originalTransactionId == rhs.originalTransactionId &&
+            lhs.gracePeriodExpiresDateMS == rhs.gracePeriodExpiresDateMS
+    }
+}
+
 extension VerifySubscriptionResult: Equatable {
 
     public static func == (lhs: VerifySubscriptionResult, rhs: VerifySubscriptionResult) -> Bool {
@@ -90,6 +117,8 @@ extension VerifySubscriptionResult: Equatable {
             return lhsExpiryDate == rhsExpiryDate && lhsReceiptItem == rhsReceiptItem
         case (.expired(let lhsExpiryDate, let lhsReceiptItem), .expired(let rhsExpiryDate, let rhsReceiptItem)):
             return lhsExpiryDate == rhsExpiryDate && lhsReceiptItem == rhsReceiptItem
+        case (.inGracePeriod(let lhsEndDate, let lhsReceiptItem, let lhsRenewals), .inGracePeriod(let rhsEndDate, let rhsReceiptItem, let rhsRenewals)):
+            return lhsEndDate == rhsEndDate && lhsReceiptItem == rhsReceiptItem && lhsRenewals == rhsRenewals
         default: return false
         }
     }

--- a/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
+++ b/Tests/SwiftyStoreKitTests/InAppReceiptTests.swift
@@ -34,7 +34,7 @@ private extension TimeInterval {
 
 extension ReceiptItem: Equatable {
 
-    init(productId: String, purchaseDate: Date, subscriptionExpirationDate: Date? = nil, cancellationDate: Date? = nil, isTrialPeriod: Bool = false, isInIntroOfferPeriod: Bool = false) {
+    init(productId: String, purchaseDate: Date, subscriptionExpirationDate: Date? = nil, cancellationDate: Date? = nil, transactionId: String? = nil, isTrialPeriod: Bool = false, isInIntroOfferPeriod: Bool = false) {
         self.init(productId: productId, quantity: 1, transactionId: UUID().uuidString, originalTransactionId: UUID().uuidString, purchaseDate: purchaseDate, originalPurchaseDate: purchaseDate, webOrderLineItemId: UUID().uuidString, subscriptionExpirationDate: subscriptionExpirationDate, cancellationDate: cancellationDate, isTrialPeriod: isTrialPeriod, isInIntroOfferPeriod: isInIntroOfferPeriod)
         self.productId = productId
         self.quantity = 1
@@ -42,7 +42,7 @@ extension ReceiptItem: Equatable {
         self.originalPurchaseDate = purchaseDate
         self.subscriptionExpirationDate = subscriptionExpirationDate
         self.cancellationDate = cancellationDate
-        self.transactionId = UUID().uuidString
+        self.transactionId = transactionId ?? UUID().uuidString
         self.originalTransactionId = UUID().uuidString
         self.webOrderLineItemId = UUID().uuidString
         self.isTrialPeriod = isTrialPeriod


### PR DESCRIPTION
Hey SwiftyStoreKit and hello GitHub! This is my very first pull request ever so any and all feedback/comments would be appreciated.

I've wanted to try my hand at the Issue #605 . (https://github.com/bizz84/SwiftyStoreKit/issues/605).
In order to do so, I've followed the following guidelines to the best of my understanding:[Reducing Subscriber Churn](https://developer.apple.com/documentation/storekit/in-app_purchase/subscriptions_and_offers/reducing_involuntary_subscriber_churn) & [PendingRenewaInfo](https://developer.apple.com/documentation/appstorereceipts/responsebody/pending_renewal_info).

I've added some XCTests and manually tested the code against some of the receipts I've been able to retrieve from users of an app of mine which all worked as expected,
**however** I did not find a way to officially test grace periods with an iTunes Sandbox Account. If anyone knows how, please do let me know.

I'll deploy this code to one of my apps where the purchase flow is handled by a server and compare them with the results this code produces locally to ensure all is running as wanted.
On a side note, deploying this code to an app that used an older version of SwiftyStoreKit should not have any unwanted effects as all of the old tests run perfectly fine and "Grace Period" would have to be enabled prior on an app to app basis.


### Let's talk code!

I tried to stick to the old code as closely as possible, but did improve where I found it to be beneficial.

1. A new `PendingRenewalInfo` type has been added. This can be used internally and externally for many wanted features and just makes our lives easier by us not having to string match all over the place. I use it when verifying the the receipt as well instead of accessing the dictionary directly. Perhaps the resulting casting to data then to the `PendingRenewalInfo` type is a tad overkill for your taste? I personally favor the strong type.

2. A new VerifySubscriptionResult has been added:
`case inGracePeriod(endDate: Date, items: [ReceiptItem], pendingRenewals: [PendingRenewalInfo])`

I've deliberately chosen this new case as to allow for more control inside the app but also, to give developers an easy way to implement this "breaking change". Consider previously you've had this code when using SwiftyStoreKit:

```
case .purchased(let expiryDate, let receiptItems):
    //do something
```

all it takes to adjust to this new version is to add this:
```
case .purchased(let expiryDate, let receiptItems), .inGracePeriod(let expiryDate, let receiptItems, _):
    //do something
```

Of course we could instead just return a `.purchased` result, but my requirements such as showing the user an alert in the case of a grace period and so on would have fallen short. In the end I feel there's no optimal way. Some developers will expect some form of control and information by knowing it's in grace period and having access to the `PendingRenewalInfo` objects and other's, especially those new to the apple ecosystem, will find this a bit overkill.

Let me know what you think!