### PR TITLE
eliminate background taskground task issue on iOS

### DIFF
--- a/Sources/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
+++ b/Sources/SwiftyStoreKit/InAppReceiptRefreshRequest.swift
@@ -46,6 +46,7 @@ class InAppReceiptRefreshRequest: NSObject, SKRequestDelegate, InAppRequest {
     let callback: RequestCallback
 
     deinit {
+        refreshReceiptRequest.cancel()
         refreshReceiptRequest.delegate = nil
     }
 


### PR DESCRIPTION
When I call `fetchReceipt`, I get a warning about not ending a background task (`SKReceiptRefreshRequest`). 
`Background Task 5 ("SKReceiptRefreshRequest"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call UIApplication.endBackgroundTask(_:) for your task in a timely manner to avoid this.`
by canceling `refreshReceiptRequest` in the `deinit`, the warning is eliminated.