### PR TITLE
Fix concurrent retrieve product request

### DIFF
--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -279,6 +279,8 @@ extension ViewController {
         case .success(let purchase):
             print("Purchase Success: \(purchase.productId)")
             return nil
+        case .deferred(purchase: _):
+            return alertWithTitle("Purchase deferred", message: "The purchase deferred")
         case .error(let error):
             print("Purchase Failed: \(error)")
             switch error.code {

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -193,6 +193,8 @@ extension ViewController {
         case .success(let purchase):
             print("Purchase Success: \(purchase.productId)")
             return alertWithTitle("Thank You", message: "Purchase completed")
+        case .deferred(purchase: _):
+            return alertWithTitle("Purchase deferred", message: "The purchase deferred")
         case .error(let error):
             print("Purchase Failed: \(error)")
             switch error.code {


### PR DESCRIPTION
Based on changes from #674
Test for concurrent retrieveProductRequest is very unstable - it crashes on read/write to the controller.inflightRequests and builder.request
