### PR TITLE
Subscription expiration reason

### DIFF
--- a/Sources/SwiftyStoreKit/InAppReceipt.swift
+++ b/Sources/SwiftyStoreKit/InAppReceipt.swift
@@ -58,6 +58,9 @@ extension ReceiptItem {
         self.originalPurchaseDate = originalPurchaseDate
         self.webOrderLineItemId = receiptInfo["web_order_line_item_id"] as? String
         self.subscriptionExpirationDate = ReceiptItem.parseDate(from: receiptInfo, key: "expires_date_ms")
+        if let expirationIntent = receiptInfo["expiration_intent"] as? String {
+            self.expirationIntent = Int(expirationIntent)
+        }
         self.cancellationDate = ReceiptItem.parseDate(from: receiptInfo, key: "cancellation_date_ms")
         if let isTrialPeriod = receiptInfo["is_trial_period"] as? String {
             self.isTrialPeriod = Bool(isTrialPeriod) ?? false

--- a/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
+++ b/Sources/SwiftyStoreKit/SwiftyStoreKit+Types.swift
@@ -209,6 +209,9 @@ public struct ReceiptItem: Purchased, Codable {
     /// The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT. This key is **only** present for **auto-renewable** subscription receipts.
     public var subscriptionExpirationDate: Date?
     
+    /// For an expired subscription, the reason for the subscription expiration.
+    public var expirationIntent: Int?
+
     /// For a transaction that was canceled by Apple customer support, the time and date of the cancellation. 
     /// 
     /// Treat a canceled receipt the same as if no purchase had ever been made.
@@ -316,6 +319,9 @@ public enum ReceiptInfoField: String {
         case original_purchase_date
         /// The expiration date for the subscription, expressed as the number of milliseconds since January 1, 1970, 00:00:00 GMT. This key is only present for auto-renewable subscription receipts.
         case expires_date
+        ///For an expired subscription, the reason for the subscription expiration.
+        case expiration_intent
+        
         /// For a transaction that was canceled by Apple customer support, the time and date of the cancellation. Treat a canceled receipt the same as if no purchase had ever been made.
         case cancellation_date
         #if os(iOS) || os(tvOS)

--- a/SwiftyStoreKit-iOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-iOS-Demo/ViewController.swift
@@ -279,6 +279,8 @@ extension ViewController {
         case .success(let purchase):
             print("Purchase Success: \(purchase.productId)")
             return nil
+        case .deferred(purchase: _):
+            return alertWithTitle("Purchase deferred", message: "The purchase deferred")
         case .error(let error):
             print("Purchase Failed: \(error)")
             switch error.code {

--- a/SwiftyStoreKit-macOS-Demo/ViewController.swift
+++ b/SwiftyStoreKit-macOS-Demo/ViewController.swift
@@ -193,6 +193,8 @@ extension ViewController {
         case .success(let purchase):
             print("Purchase Success: \(purchase.productId)")
             return alertWithTitle("Thank You", message: "Purchase completed")
+        case .deferred(purchase: _):
+            return alertWithTitle("Purchase deferred", message: "The purchase deferred")
         case .error(let error):
             print("Purchase Failed: \(error)")
             switch error.code {


### PR DESCRIPTION
[Use case - "Handle Lapsed Subscriptions"](https://developer.apple.com/documentation/appstorereceipts/expiration_intent)

[Specification](https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase/subscriptions_and_offers/handling_subscriptions_billing)

Based on changes from https://github.com/bizz84/SwiftyStoreKit/pull/674